### PR TITLE
KEY-87 - Add metrics endpoint

### DIFF
--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -18,13 +18,14 @@ import (
 )
 
 var (
-	port     string
-	certFile string
-	keyFile  string
-	caFile   string
-	keyDir   string
-	silent   bool
-	keyName  *regexp.Regexp
+	port        string
+	metricsPort string
+	certFile    string
+	keyFile     string
+	caFile      string
+	keyDir      string
+	silent      bool
+	keyName     *regexp.Regexp
 )
 
 func init() {
@@ -34,6 +35,7 @@ func init() {
 	flag.StringVar(&caFile, "ca-file", "keyless-ca.pem", "Keyless client certificate authority")
 	flag.StringVar(&keyDir, "private-key-directory", "keys/", "Directory in which private keys are stored with .key extension")
 	flag.StringVar(&port, "port", "2407", "Keyless port on which to listen")
+	flag.StringVar(&metricsPort, "metrics-port", "2408", "Port where the metrics API is served")
 	flag.BoolVar(&silent, "silent", false, "Whether or not to output debugging information")
 	flag.Parse()
 }
@@ -46,7 +48,8 @@ func main() {
 		logOut = os.Stdout
 	}
 
-	s, err := server.NewServerFromFile(certFile, keyFile, caFile, net.JoinHostPort("", port), logOut)
+	s, err := server.NewServerFromFile(certFile, keyFile, caFile,
+		net.JoinHostPort("", port), net.JoinHostPort("", metricsPort), logOut)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ const (
 	rsaPrivKey   = "testdata/rsa.key"
 	ecdsaPrivKey = "testdata/ecdsa.key"
 	addr         = "rsa-server:3407"
+	metricsAddr  = "rsa-server:80"
 )
 
 var (
@@ -29,7 +30,7 @@ func init() {
 	var key crypto.Signer
 	var p *pem.Block
 
-	s, err = NewServerFromFile(certFile, keyFile, caFile, addr, os.Stdout)
+	s, err = NewServerFromFile(certFile, keyFile, caFile, addr, metricsAddr, os.Stdout)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Add metrics endpoint using go-metrics to measure the number of requests and their average response latency on the keyserver.

Running metrics HTTP server can be seen here: http://keyserver.jhaven.me:2408/metrics?indent=1

A standard output should look something like:
```
{
        "Invalid Request Rate": {
                "15m.rate": 0,
                "1m.rate": 0,
                "5m.rate": 0,
                "count": 0,
                "mean.rate": 0
        },
        "Request Rate": {
                "15m.rate": 0.002179432534806779,
                "1m.rate": 0.02490778899904623,
                "5m.rate": 0.006288975787638508,
                "count": 2,
                "mean.rate": 0.050002368910979464
        },
        "Response Latency": {
                "15m.rate": 0.002179432534806779,
                "1m.rate": 0.02490778899904623,
                "5m.rate": 0.006288975787638508,
                "75%": 7.38846e+06,
                "95%": 7.38846e+06,
                "99%": 7.38846e+06,
                "99.9%": 7.38846e+06,
                "count": 2,
                "max": 7388460,
                "mean": 3.799837e+06,
                "mean.rate": 0.050002421981064166,
                "median": 3.799837e+06,
                "min": 211214,
                "stddev": 3.588623e+06
        }
}
```