### PR TITLE
Add generic Keystore for server private keys.

### DIFF
--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -50,7 +50,9 @@ func main() {
 	}
 
 	for _, key := range keys {
-		s.RegisterKey(key)
+		if err := s.Keys.Add(nil, key); err != nil {
+			log.Errorf("Unable to add key: %v", err)
+		}
 	}
 
 	log.Fatal(s.ListenAndServe())

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -55,7 +55,7 @@ func init() {
 	if priv, err = x509.ParsePKCS1PrivateKey(p.Bytes); err != nil {
 		log.Fatal(err)
 	}
-	if err = s.RegisterKey(priv); err != nil {
+	if err = s.Keys.Add(nil, priv); err != nil {
 		log.Fatal(err)
 	}
 
@@ -66,7 +66,7 @@ func init() {
 	if priv, err = x509.ParseECPrivateKey(p.Bytes); err != nil {
 		log.Fatal(err)
 	}
-	if err = s.RegisterKey(priv); err != nil {
+	if err = s.Keys.Add(nil, priv); err != nil {
 		log.Fatal(err)
 	}
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -120,7 +120,7 @@ func TestTLSProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RegisterKey(rsaKey); err != nil {
+	if err := s.Keys.Add(nil, rsaKey); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This will allow for smarter lazy-loading implementations capable of loading keys based on incoming requests.