### PR TITLE
Certficate API endpoint changed.

### DIFF
--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cloudflare/gokeyless/server"
 )
 
+var defaultEndpoint = "https://api.cloudflare.com/client/v4/certificates/"
+
 var (
 	initToken    string
 	initCertFile string
@@ -34,7 +36,7 @@ func init() {
 	flag.StringVar(&initToken, "init-token", "token.json", "API token used for server initialization")
 	flag.StringVar(&initCertFile, "init-cert", "default.pem", "Default certificate used for server initialization")
 	flag.StringVar(&initKeyFile, "init-key", "default-key.pem", "Default key used for server initialization")
-	flag.StringVar(&initEndpoint, "init-endpoint", "https://api.cloudflare.com/client/v4/certificates", "API endpoint for server initialization")
+	flag.StringVar(&initEndpoint, "init-endpoint", defaultEndpoint, "API endpoint for server initialization")
 	flag.StringVar(&certFile, "cert", "server.pem", "Keyless server authentication certificate")
 	flag.StringVar(&keyFile, "key", "server-key.pem", "Keyless server authentication key")
 	flag.StringVar(&caFile, "ca-file", "keyless_cacert.pem", "Keyless client certificate authority")

--- a/cmd/gokeyless/initialize.go
+++ b/cmd/gokeyless/initialize.go
@@ -65,6 +65,7 @@ func initAPICall(token *apiToken, csr string) ([]byte, error) {
 
 	req.Header.Set("X-Auth-Key", token.Token)
 
+	log.Infof("making API call: %s", initEndpoint)
 	resp, err := new(http.Client).Do(req)
 	if err != nil {
 		return nil, err
@@ -84,7 +85,7 @@ func initAPICall(token *apiToken, csr string) ([]byte, error) {
 
 	if !apiResp.Success {
 		errs, _ := json.Marshal(apiResp.Errors)
-		return nil, fmt.Errorf("certificate API call failed: %s", errs)
+		return nil, fmt.Errorf("certificate API call returned HTTP %d | %s", resp.StatusCode, errs)
 	}
 
 	if cert, ok := apiResp.Result["certificate"]; ok {


### PR DESCRIPTION
Default API endpoint has changed:

* `https://api.cloudflare.com/client/v4/certificates` => `https://api.cloudflare.com/client/v4/certificates/`
