### PR TITLE
Modify the header used for initialization auth

### DIFF
--- a/cmd/gokeyless/initialize.go
+++ b/cmd/gokeyless/initialize.go
@@ -63,7 +63,7 @@ func initAPICall(token *apiToken, csr string) ([]byte, error) {
 		return nil, err
 	}
 
-	req.Header.Set("X-Auth-Key", token.Token)
+	req.Header.Set("X-Auth-User-Service-Key", token.Token)
 
 	log.Infof("making API call: %s", initEndpoint)
 	resp, err := new(http.Client).Do(req)


### PR DESCRIPTION
To be consistent with the CloudFlare API, use the right header for service tokens, necessary for https://api.cloudflare.com/client/v4/certificates/.