### PR TITLE
Use a more sensible name for the service API key.

### DIFF
--- a/cmd/gokeyless/initialize.go
+++ b/cmd/gokeyless/initialize.go
@@ -189,7 +189,7 @@ func tokenPrompt() *apiToken {
 
 	fmt.Print("Keyserver Hostname: ")
 	fmt.Scanln(&token.Host)
-	fmt.Print("Origin CA Key: ")
+	fmt.Print("Certificates API Key: ")
 	fmt.Scanln(&token.Token)
 
 	return token


### PR DESCRIPTION
This name is consistent with the API documentation.