### PR TITLE
introduce Conn and a unexported connection pool into client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -118,7 +118,7 @@ func (c *Client) ClearBlacklist() {
 
 // Dial smartly establishes a connection to a registered keyless server
 // or reuses an existing connection if possible.
-func (c *Client) Dial(ski gokeyless.SKI) (*gokeyless.Conn, error) {
+func (c *Client) Dial(ski gokeyless.SKI) (*Conn, error) {
 	c.m.RLock()
 	r, ok := c.remotes[ski]
 	c.m.RUnlock()

--- a/client/keys.go
+++ b/client/keys.go
@@ -79,9 +79,8 @@ func (key *PrivateKey) execute(op gokeyless.Op, msg []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
-	result, err := conn.DoOperation(&gokeyless.Operation{
+	result, err := conn.Conn.DoOperation(&gokeyless.Operation{
 		Opcode:   op,
 		Payload:  msg,
 		SKI:      key.ski,
@@ -91,6 +90,7 @@ func (key *PrivateKey) execute(op gokeyless.Op, msg []byte) ([]byte, error) {
 		SNI:      key.sni,
 	})
 	if err != nil {
+		defer conn.Close()
 		return nil, err
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -14,7 +14,6 @@ import (
 type Conn struct {
 	*tls.Conn
 	sync.Mutex
-	users     uint32
 	listeners map[uint32]chan *Header
 }
 
@@ -22,22 +21,8 @@ type Conn struct {
 func NewConn(inner *tls.Conn) *Conn {
 	return &Conn{
 		Conn:      inner,
-		users:     1,
 		listeners: make(map[uint32]chan *Header),
 	}
-}
-
-// Use marks conn as used by the current goroutine, returning ok if
-// the Conn is open. This should be accompanied by a later Close()
-// call.
-func (c *Conn) Use() bool {
-	c.Lock()
-	defer c.Unlock()
-	if c.users == 0 {
-		return false
-	}
-	c.users++
-	return true
 }
 
 // Close marks conn as closed and closes the inner net.Conn if it is
@@ -45,19 +30,19 @@ func (c *Conn) Use() bool {
 func (c *Conn) Close() {
 	c.Lock()
 	defer c.Unlock()
-	c.users--
-	if c.users == 0 {
+	if c.Conn != nil {
 		if err := c.Conn.Close(); err != nil {
 			log.Errorf("Unable to close connection: %v", err)
 		}
 	}
+	c.Conn = nil
 }
 
 // IsClosed returns true if the connection has been closed.
 func (c *Conn) IsClosed() bool {
 	c.Lock()
 	defer c.Unlock()
-	return c.users == 0
+	return c.Conn == nil
 }
 
 // WriteHeader marshals and header and writes it to the conn.

--- a/conn.go
+++ b/conn.go
@@ -47,6 +47,8 @@ func (c *Conn) IsClosed() bool {
 
 // WriteHeader marshals and header and writes it to the conn.
 func (c *Conn) WriteHeader(h *Header) error {
+	c.Lock()
+	defer c.Unlock()
 	b, err := h.MarshalBinary()
 	if err != nil {
 		return err


### PR DESCRIPTION
1. remove the reference count in gokeyless.Conn. The use of such
   reference count is questionable since our goal is simply keeping
   the underlying TLS connection alive.

2. Add a Conn type into client, which wraps around gokeyless.Conn.
   This Conn type associates the original gokeyless.Conn with a
   server address and a health checking goroutine.

   When initializing client.Conn, a recurrent goroutine is spawned
   to monitor the connection.

3. Keep all established client.Conn in a hashmap based connection pool,
   indexed by remote address. When a connection is not longer usable,
   either discovered by the corresponding health checker or the keyless
   operation, the connection is removed from the pool. When connecting
   to a remote address, always check with connection pool first.

4. Using client to dial a remote address will return
   client.Conn, rather than gokeyless.Conn. And so we can make a
   client-based gokeyless proxy with automatic health check and
   connection management. Through testing, we can see that when
   a remote server shuts down, the corrsponding connection will be
   closed, and new keyless request will trigger new connection
   attempts, rather than keeping using the broken one.