### PR TITLE
add a test on connection selection with optimized performance

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -346,7 +346,7 @@ func (g *Group) Dial(c *Client) (conn *Conn, err error) {
 			if err != nil {
 				i.latency.Reset()
 				i.errorCount++
-				log.Infof("Dial failed: %v", err)
+				log.Infof("ping failed: %v", err)
 				continue
 			}
 
@@ -358,7 +358,7 @@ func (g *Group) Dial(c *Client) (conn *Conn, err error) {
 				defer conn.Close()
 				i.latency.Reset()
 				i.errorCount++
-				log.Infof("Ping failed: %v", err)
+				log.Infof("ping failed: %v", err)
 			} else {
 				log.Debug("ping duration:", duration)
 				i.latency.Update(duration)

--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -5,7 +5,10 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cloudflare/gokeyless"
 	"github.com/cloudflare/gokeyless/server"
@@ -16,6 +19,7 @@ const (
 	serverKey    = "testdata/server-key.pem"
 	keylessCA    = "testdata/ca.pem"
 	serverAddr   = "localhost:3407"
+	slowAddr     = "localhost:5103"
 	rsaPrivKey   = "testdata/rsa.key"
 	ecdsaPrivKey = "testdata/ecdsa.key"
 
@@ -29,8 +33,6 @@ const (
 var (
 	s          *server.Server
 	c          *Client
-	rsaKey     *PrivateKey
-	ecdsaKey   *PrivateKey
 	rsaSKI     gokeyless.SKI
 	ecdsaSKI   gokeyless.SKI
 	remote     Remote
@@ -43,7 +45,6 @@ func TestMain(t *testing.T) {
 	var pemBytes []byte
 	var p *pem.Block
 	var priv crypto.Signer
-	var pub crypto.PublicKey
 
 	// Setup keyless server
 	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA, serverAddr, "")
@@ -104,33 +105,10 @@ func TestMain(t *testing.T) {
 
 	// register both public keys with empty remote server so
 	// DefaultRemote will be used
-	if pemBytes, err = ioutil.ReadFile(rsaPubKey); err != nil {
-		t.Fatal(err)
-	}
-	p, _ = pem.Decode(pemBytes)
-	if pub, err = x509.ParsePKIXPublicKey(p.Bytes); err != nil {
-		t.Fatal(err)
-	}
-	if rsaSKI, err = gokeyless.GetSKI(pub); err != nil {
-		t.Fatal(err)
-	}
-	if rsaKey, err = c.RegisterPublicKey("", pub); err != nil {
-		t.Fatal(err)
-	}
+	registerCertFile(rsaPubKey, t)
 
-	if pemBytes, err = ioutil.ReadFile(ecdsaPubKey); err != nil {
-		t.Fatal(err)
-	}
-	p, _ = pem.Decode(pemBytes)
-	if pub, err = x509.ParsePKIXPublicKey(p.Bytes); err != nil {
-		t.Fatal(err)
-	}
-	if ecdsaSKI, err = gokeyless.GetSKI(pub); err != nil {
-		t.Fatal(err)
-	}
-	if ecdsaKey, err = c.RegisterPublicKey("", pub); err != nil {
-		t.Fatal(err)
-	}
+	registerCertFile(ecdsaPubKey, t)
+
 }
 
 func TestRemoteGroup(t *testing.T) {
@@ -152,7 +130,80 @@ func TestBadRemote(t *testing.T) {
 	c.remotes = map[gokeyless.SKI]Remote{}
 
 	// register the ECDDSA certificate again with the default broken remote
-	pemBytes, err := ioutil.ReadFile(ecdsaPubKey)
+	registerCertFile(ecdsaPubKey, t)
+
+	_, err := c.Dial(ecdsaSKI)
+	if err == nil {
+		t.Fatal("bad remote management")
+	}
+}
+
+func TestSlowServer(t *testing.T) {
+	// Setup keyless server
+	s2, err := server.NewServerFromFile(serverCert, serverKey, keylessCA,
+		slowAddr, slowAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := net.Listen("tcp", slowAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := slowListener{l}
+
+	go func() {
+		if err := s2.Serve(&sl); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// wait for server to come up
+	time.Sleep(100 * time.Millisecond)
+
+	// clear cached remotes and set a remote group of slowAddr and serverAddr
+	remote, err := c.LookupServer(serverAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slowRemote, err := c.LookupServer(slowAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.DefaultRemote = remote.Add(slowRemote)
+
+	c.servers = map[string]Remote{}
+	c.remotes = map[gokeyless.SKI]Remote{}
+
+	// register the ECDDSA certificate again with the default broken remote
+	registerCertFile(ecdsaPubKey, t)
+
+	conn, err := c.Dial(ecdsaSKI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initially picked the slow-down server at port 5103
+	if !strings.HasSuffix(conn.addr, ":5103") {
+		t.Fatal("bad remote addr:", conn.addr)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// After a few health check, must pick the normal server at port 3407
+	conn, err = c.Dial(ecdsaSKI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(conn.addr, ":3407") {
+		t.Fatal("bad remote addr:", conn.addr)
+	}
+}
+
+// helper function register a public key from a file.
+func registerCertFile(filepath string, t *testing.T) {
+	pemBytes, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,12 +212,67 @@ func TestBadRemote(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ecdsaKey, err = c.RegisterPublicKey("", pub); err != nil {
+	if _, err = c.RegisterPublicKey("", pub); err != nil {
 		t.Fatal(err)
 	}
+}
 
-	_, err = c.Dial(ecdsaSKI)
-	if err == nil {
-		t.Fatal("bad remote management")
+// slowListener returns a slowConn
+type slowListener struct {
+	l net.Listener
+}
+
+// slowConn slows down each read and write by 10 ms.
+type slowConn struct {
+	c net.Conn
+}
+
+func (sl *slowListener) Accept() (net.Conn, error) {
+	c, err := sl.l.Accept()
+	if err != nil {
+		return nil, err
 	}
+	return &slowConn{c}, nil
+}
+
+func (sl *slowListener) Close() error {
+	return sl.l.Close()
+}
+
+func (sl *slowListener) Addr() net.Addr {
+	return sl.l.Addr()
+}
+
+func (sc *slowConn) Read(b []byte) (n int, err error) {
+	time.Sleep(10 * time.Millisecond)
+	return sc.c.Read(b)
+}
+
+func (sc *slowConn) Write(b []byte) (n int, err error) {
+	time.Sleep(10 * time.Millisecond)
+	return sc.c.Write(b)
+}
+
+func (sc *slowConn) Close() error {
+	return sc.c.Close()
+}
+
+func (sc *slowConn) LocalAddr() net.Addr {
+	return sc.c.LocalAddr()
+}
+
+func (sc *slowConn) RemoteAddr() net.Addr {
+	return sc.c.RemoteAddr()
+}
+
+func (sc *slowConn) SetDeadline(t time.Time) error {
+	return sc.c.SetDeadline(t)
+}
+
+func (sc *slowConn) SetReadDeadline(t time.Time) error {
+	return sc.c.SetReadDeadline(t)
+}
+
+func (sc *slowConn) SetWriteDeadline(t time.Time) error {
+	return sc.c.SetWriteDeadline(t)
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -24,9 +24,6 @@ func newStatistics() *statistics {
 			Help: "Number of invalid requests.",
 		}),
 	}
-	prometheus.MustRegister(stats.requests)
-	prometheus.MustRegister(stats.requestsInvalid)
-
 	return stats
 }
 
@@ -42,6 +39,9 @@ func (stats *statistics) logRequest(requestBegin time.Time) {
 }
 
 func (s *Server) MetricsListenAndServe() error {
+	prometheus.MustRegister(s.stats.requests)
+	prometheus.MustRegister(s.stats.requestsInvalid)
+
 	if s.MetricsAddr != "" {
 		http.Handle("/metrics", prometheus.Handler())
 

--- a/server/server.go
+++ b/server/server.go
@@ -393,7 +393,8 @@ func (s *Server) ListenAndServe() error {
 		return err
 	}
 
-	log.Infof("Listenting at %s\n", l.Addr())
+	s.Addr = l.Addr().String()
+	log.Infof("Listening at %s\n", l.Addr())
 
 	return s.Serve(l)
 }


### PR DESCRIPTION
1. refactor client tests a little bit
2. add a test that sets up two backend servers. One server is running
   with artifical slow connection, and the other is unchanged. Test
   that client can pick the connection with better speed.
3. refactored server code a little bit such that NewServer() won't register
   global prometheus metrics. So we can run two servers side by side in
   tests otherwise prometheus will complain about duplicate metrics
   registration.