### PR TITLE
Add support for RSA keytypes in NewGetCertificate.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -395,10 +396,17 @@ func (c *Client) NewGetCertificate(sigAlgSort sigAlgSort, server string) (func(c
 			return nil, err
 		}
 
-		cert.PrivateKey, err = c.RegisterPublicKeyTemplate(server, cert.Leaf.PublicKey, hello.ServerName, nil)
+		priv, err := c.RegisterPublicKeyTemplate(server, cert.Leaf.PublicKey, hello.ServerName, nil)
 		if err != nil {
 			return nil, err
 		}
+
+		if _, ok := cert.Leaf.PublicKey.(*rsa.PublicKey); ok {
+			cert.PrivateKey = RSAPrivateKey{PrivateKey: *priv}
+		} else {
+			cert.PrivateKey = priv
+		}
+
 		return
 	}, nil
 }

--- a/client/keys.go
+++ b/client/keys.go
@@ -22,13 +22,20 @@ type PrivateKey struct {
 	clientIP net.IP
 	serverIP net.IP
 	sni      string
-	crypto.Signer
-	crypto.Decrypter
 }
 
-// Public returns the public key corresponding to the opaque, private key.
+type RSAPrivateKey struct {
+	PrivateKey
+}
+
+// Public returns the public key corresponding to the opaque private key.
 func (key *PrivateKey) Public() crypto.PublicKey {
 	return key.public
+}
+
+// Public returns the public key corresponding to the opaque private key.
+func (key *RSAPrivateKey) Public() crypto.PublicKey {
+	return key.PrivateKey.public
 }
 
 func signOpFromKeyHash(key *PrivateKey, h crypto.Hash) gokeyless.Op {
@@ -121,8 +128,13 @@ func (key *PrivateKey) Sign(r io.Reader, msg []byte, opts crypto.SignerOpts) ([]
 	return key.execute(op, msg)
 }
 
+// Sign implements the crypto.Signer operation for the given key.
+func (key *RSAPrivateKey) Sign(r io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return key.PrivateKey.Sign(r, msg, opts)
+}
+
 // Decrypt implements the crypto.Decrypter operation for the given key.
-func (key *PrivateKey) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
+func (key *RSAPrivateKey) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
 	opts1v15, ok := opts.(*rsa.PKCS1v15DecryptOptions)
 	if opts != nil && !ok {
 		return nil, errors.New("invalid options for Decrypt")

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -30,7 +30,7 @@ const (
 var (
 	s        *server.Server
 	c        *client.Client
-	rsaKey   *client.PrivateKey
+	rsaKey   *client.RSAPrivateKey
 	ecdsaKey *client.PrivateKey
 	remote   client.Remote
 )
@@ -99,9 +99,11 @@ func init() {
 	if pub, err = x509.ParsePKIXPublicKey(p.Bytes); err != nil {
 		log.Fatal(err)
 	}
-	if rsaKey, err = c.RegisterPublicKey(serverAddr, pub); err != nil {
+	var privKey *client.PrivateKey
+	if privKey, err = c.RegisterPublicKey(serverAddr, pub); err != nil {
 		log.Fatal(err)
 	}
+	rsaKey = &client.RSAPrivateKey{PrivateKey: *privKey}
 
 	if pemBytes, err = ioutil.ReadFile(ecdsaPubKey); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Split out PrivateKey (crypto.Signer) from RSAPrivateKey (crypto.Signer & crypto.Decrypter). Allow NewGetCertificate to return correct type.