### PR TITLE
Add ErrCertNotFound to (Error).Error()

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -205,6 +205,8 @@ func (e Error) Error() string {
 		errStr = "malformed message"
 	case ErrInternal:
 		errStr = "internal error"
+	case ErrCertNotFound:
+		errStr = "certificate not found"
 	default:
 		errStr = "unknown error"
 	}


### PR DESCRIPTION
`(Error).Error()` should return an error string for `ErrCertNotFound`

At present `ErrCertNotFound` is missing from `(Error).Error()`. It was missed out of dac2fad.

This PR adds `ErrCertNotFound` to the switch statement and changes nothing more.