### PR TITLE
SKI string format should be hex encoding

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -9,8 +9,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -225,7 +225,7 @@ var nilSKI SKI
 
 // String returns a canonical Base 64 encoded SKI string.
 func (ski SKI) String() string {
-	return base64.StdEncoding.EncodeToString(ski[:])
+	return hex.EncodeToString(ski[:])
 }
 
 // Equal compares two SKIs for equality.


### PR DESCRIPTION
base64 encoding doesn't make sense