### PR TITLE
Make GetCertificate pattern more flexible.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3,10 +3,8 @@ package gokeyless
 import (
 	"bytes"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
-	"net"
 	"sync"
 
 	"github.com/cloudflare/cfssl/log"
@@ -241,30 +239,4 @@ func (c *Conn) RespondError(id uint32, err Error) error {
 			Opcode:  OpError,
 			Payload: []byte{byte(err)},
 		})
-}
-
-// GetCertificate fetches a certificate from a remote keyserver.
-func (c *Conn) GetCertificate(sigAlgs SigAlgs, serverIP net.IP, sni string) ([]byte, error) {
-	result, err := c.DoOperation(&Operation{
-		Opcode:   OpCertificateRequest,
-		SNI:      sni,
-		ServerIP: serverIP,
-		SigAlgs:  sigAlgs,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Opcode != OpResponse {
-		if result.Opcode == OpError {
-			return nil, result.GetError()
-		}
-		return nil, fmt.Errorf("wrong response opcode: %v", result.Opcode)
-	}
-
-	if len(result.Payload) == 0 {
-		return nil, errors.New("empty payload")
-	}
-
-	return result.Payload, nil
 }

--- a/protocol_string.go
+++ b/protocol_string.go
@@ -5,13 +5,13 @@ package gokeyless
 import "fmt"
 
 const (
-	_Tag_name_0 = "TagCertificateDigestTagServerNameTagClientIPTagSubjectKeyIdentifierTagServerIPTagSigAlgs"
+	_Tag_name_0 = "TagCertificateDigestTagServerNameTagClientIPTagSubjectKeyIdentifierTagServerIP"
 	_Tag_name_1 = "TagOpcodeTagPayload"
 	_Tag_name_2 = "TagPadding"
 )
 
 var (
-	_Tag_index_0 = [...]uint8{0, 20, 33, 44, 67, 78, 88}
+	_Tag_index_0 = [...]uint8{0, 20, 33, 44, 67, 78}
 	_Tag_index_1 = [...]uint8{0, 9, 19}
 	_Tag_index_2 = [...]uint8{0, 10}
 )
@@ -34,7 +34,7 @@ func (i Tag) String() string {
 const (
 	_Op_name_0 = "OpRSADecryptOpRSASignMD5SHA1OpRSASignSHA1OpRSASignSHA224OpRSASignSHA256OpRSASignSHA384OpRSASignSHA512"
 	_Op_name_1 = "OpECDSASignMD5SHA1OpECDSASignSHA1OpECDSASignSHA224OpECDSASignSHA256OpECDSASignSHA384OpECDSASignSHA512"
-	_Op_name_2 = "OpCertificateRequest"
+	_Op_name_2 = "OpGetCertificate"
 	_Op_name_3 = "OpRSAPSSSignSHA256OpRSAPSSSignSHA384OpRSAPSSSignSHA512"
 	_Op_name_4 = "OpResponseOpPingOpPongOpActivate"
 	_Op_name_5 = "OpError"
@@ -43,7 +43,7 @@ const (
 var (
 	_Op_index_0 = [...]uint8{0, 12, 28, 41, 56, 71, 86, 101}
 	_Op_index_1 = [...]uint8{0, 18, 33, 50, 67, 84, 101}
-	_Op_index_2 = [...]uint8{0, 20}
+	_Op_index_2 = [...]uint8{0, 16}
 	_Op_index_3 = [...]uint8{0, 18, 36, 54}
 	_Op_index_4 = [...]uint8{0, 10, 16, 22, 32}
 	_Op_index_5 = [...]uint8{0, 7}

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go4.org/testing/functest"
 
+	"github.com/cloudflare/gokeyless"
 	"github.com/cloudflare/gokeyless/client"
 )
 
@@ -171,10 +172,9 @@ func TestRSADecrypt(t *testing.T) {
 	}
 }
 
-func TestCertLoad(t *testing.T) {
+func TestGetCertificate(t *testing.T) {
 	certChainBytes, _ := ioutil.ReadFile(tlsChain)
 
-	var chain []byte
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -185,13 +185,13 @@ func TestCertLoad(t *testing.T) {
 	}
 	defer conn.Close()
 
-	// Send sigalgs, expect correct cert
-	sigAlgs := make([]byte, 2)
-	if chain, err = conn.GetCertificate(sigAlgs, nil, ""); err != nil {
+	resp, err := conn.DoOperation(&gokeyless.Operation{
+		Opcode: gokeyless.OpGetCertificate,
+	})
+	if err != nil {
 		t.Fatal(err)
-	}
-	if bytes.Compare(certChainBytes, chain) != 0 {
-		t.Logf("m: %dB\tcertChain: %dB", len(certChainBytes), len(chain))
+	} else if bytes.Compare(certChainBytes, resp.Payload) != 0 {
+		t.Logf("m: %dB\tcertChain: %dB", len(certChainBytes), len(resp.Payload))
 		t.Fatal("certificate chain mismatch")
 	}
 }


### PR DESCRIPTION
The previous pattern was to put additional certificate-fetching
information into the Keyless protocol (for example, SigAlgs) and
pass this to a CertLoader manually.

Instead, we want server and client implementations of
GetCertificate to pack arbitrary information into the payload of
the operation.

- Remove (now) out-of-place code: NewGetCertificate,
  Conn.GetCertificate, SigAlgs tag.
- Simplify implementation of RSAPrivateKey->Decrypter.
- Implement DialDefault, and make some naming more consistent.