### PR TITLE
Support limited concurrency on the wire.

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -317,7 +317,8 @@ type item struct {
 // A Group is a Remote consisting of a load-balanced set of external servers.
 type Group struct {
 	sync.Mutex
-	remotes []*item
+	remotes     []*item
+	lastPingAll time.Time
 }
 
 // NewGroup creates a new group from a set of remotes.
@@ -369,38 +370,43 @@ func (g *Group) Dial(c *Client) (conn *Conn, err error) {
 
 	// loop through all remote servers for performance measurement
 	// in a separate goroutine
-	go func() {
-		time.Sleep(100 * time.Microsecond)
-		g.Lock()
-		for _, i := range g.remotes {
-			conn, err := i.Dial(c)
-			if err != nil {
-				i.latency.Reset()
-				i.errorCount++
-				log.Infof("ping failed: %v", err)
-				continue
-			}
-
-			start := time.Now()
-			err = conn.Ping(nil)
-			duration := time.Since(start)
-
-			if err != nil {
-				defer conn.Close()
-				i.latency.Reset()
-				i.errorCount++
-				log.Infof("ping failed: %v", err)
-			} else {
-				log.Debug(conn.addr, " ping duration:", duration)
-				i.latency.Update(duration)
-			}
-		}
-		sort.Sort(g)
-
-		g.Unlock()
-	}()
+	if time.Since(g.lastPingAll) > time.Second {
+		g.lastPingAll = time.Now()
+		go g.pingAll(c)
+	}
 
 	return conn, nil
+}
+
+func (g *Group) pingAll(c *Client) {
+	time.Sleep(100 * time.Microsecond)
+	g.Lock()
+	for _, i := range g.remotes {
+		conn, err := i.Dial(c)
+		if err != nil {
+			i.latency.Reset()
+			i.errorCount++
+			log.Infof("ping failed: %v", err)
+			continue
+		}
+
+		start := time.Now()
+		err = conn.Ping(nil)
+		duration := time.Since(start)
+
+		if err != nil {
+			defer conn.Close()
+			i.latency.Reset()
+			i.errorCount++
+			log.Infof("ping failed: %v", err)
+		} else {
+			log.Debug(conn.addr, " ping duration:", duration)
+			i.latency.Update(duration)
+		}
+	}
+	sort.Sort(g)
+
+	g.Unlock()
 }
 
 // Len(), Less(i, j) and Swap(i,j) implements sort.Interface

--- a/conn.go
+++ b/conn.go
@@ -45,6 +45,11 @@ func (c *Conn) Close() {
 
 // IsClosed returns true if the connection has been closed.
 func (c *Conn) IsClosed() bool {
+	c.read.Lock()
+	c.write.Lock()
+	defer c.read.Unlock()
+	defer c.write.Unlock()
+
 	return c.Conn == nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sync"
 	"time"
 
@@ -233,10 +234,12 @@ func (s *Server) handle(conn *gokeyless.Conn) {
 }
 
 func (s *Server) handleReq(conn *gokeyless.Conn, ch chan *gokeyless.Header) {
+	runtime.LockOSThread()
+
 	var connError error
 	for connError == nil {
-		h := <-ch
-		if h == nil {
+		h, more := <-ch
+		if !more {
 			break
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -203,6 +203,13 @@ func NewServerFromFile(certFile, keyFile, caFile, addr, metricsAddr string) (*Se
 func (s *Server) handle(conn *gokeyless.Conn) {
 	defer conn.Close()
 	log.Debug("Handling new connection...")
+
+	ch := make(chan *gokeyless.Header, 10)
+	defer close(ch)
+	for i := 0; i < 10; i++ {
+		go s.handleReq(conn, ch)
+	}
+
 	// Continuosly read request Headers from conn and respond
 	// until a connection error (Read/Write failure) is encountered.
 	var connError error
@@ -213,6 +220,24 @@ func (s *Server) handle(conn *gokeyless.Conn) {
 		if h, connError = conn.ReadHeader(); connError != nil {
 			s.stats.logConnFailure()
 			continue
+		}
+
+		ch <- h
+	}
+
+	if connError == io.EOF {
+		log.Debug("connection closed by client")
+	} else {
+		log.Errorf("connection error: %v\n", connError)
+	}
+}
+
+func (s *Server) handleReq(conn *gokeyless.Conn, ch chan *gokeyless.Header) {
+	var connError error
+	for connError == nil {
+		h := <-ch
+		if h == nil {
+			break
 		}
 
 		requestBegin := time.Now()
@@ -352,12 +377,6 @@ func (s *Server) handle(conn *gokeyless.Conn) {
 
 		connError = conn.Respond(h.ID, sig)
 		s.stats.logRequest(requestBegin)
-	}
-
-	if connError == io.EOF {
-		log.Debug("connection closed by client")
-	} else {
-		log.Errorf("connection error: %v\n", connError)
 	}
 }
 


### PR DESCRIPTION
- The client-side locked itself into being serial. Fix that.
- Make the server's read-loop delegate to a pool of workers.
- Also, stop pinging all the time.