### PR TITLE
address #115, rewrite Group Dial

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -149,6 +149,10 @@ func UnixRemote(unixAddr, serverName string) (Remote, error) {
 	return NewServer(addr, serverName), nil
 }
 
+// LookupIPs resolves host with resolvers list sequentially unitl
+// one resolver can answer the request. It falls
+// back to use system default for final resolution if none of resolvers
+// can answer.
 func LookupIPs(resolvers []string, host string) (ips []net.IP, err error) {
 	m := new(dns.Msg)
 	dnsClient := new(dns.Client)

--- a/client/remote.go
+++ b/client/remote.go
@@ -426,6 +426,7 @@ func (g *Group) PingAll(c *Client) {
 
 	g.Lock()
 	g.remotes = remotes
+	g.lastPingAll = time.Now()
 	g.Unlock()
 }
 

--- a/client/remote.go
+++ b/client/remote.go
@@ -52,8 +52,8 @@ type singleRemote struct {
 func init() {
 	poolEvict := func(key string, value interface{}) {
 		conn, ok := value.(*Conn)
-		if ok && !conn.Conn.IsClosed() {
-			conn.Close()
+		if ok && conn != nil && conn.Conn != nil {
+			conn.Conn.Close()
 		}
 	}
 	connPool = &connPoolType{
@@ -75,7 +75,6 @@ func NewConn(addr string, conn *gokeyless.Conn) *Conn {
 // Close closes a Conn and remove it from the conn pool
 func (conn *Conn) Close() {
 	conn.Conn.Close()
-	connPool.Remove(conn.addr)
 }
 
 // KeepAlive keeps Conn reusable in the conn pool

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ type Keystore interface {
 	Get(*gokeyless.Operation) (crypto.Signer, bool)
 }
 
-// NewKeystore returns a new default memory-based static keystore.
+// NewDefaultKeystore returns a new default memory-based static keystore.
 func NewDefaultKeystore() *DefaultKeystore {
 	return &DefaultKeystore{
 		skis:      make(map[gokeyless.SKI]crypto.Signer),


### PR DESCRIPTION
- it satisfy three design goals
  - load balancing through shuffle top n remotes (n=3, adjustable)
  - robust failover: it will try all top n remotes when dial failure happens
  - dynamic server reordering based on ping performances by a separate
    goroutine and proper locking.

- the turnaround time of Dial function is kept low.
- the background ping measurement in PingAll can take arbitrary long time
  without affecting Dial.