### PR TITLE
address #112, remove AKI whitelist

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -99,10 +99,6 @@ func (c *Conn) ReadHeader() (*Header, error) {
 	if err := h.Body.UnmarshalBinary(body); err != nil {
 		return nil, err
 	}
-	peerCerts := c.ConnectionState().PeerCertificates
-	if len(peerCerts) > 0 && len(peerCerts[0].AuthorityKeyId) == len(h.Body.AKI) {
-		copy(h.Body.AKI[:], peerCerts[0].AuthorityKeyId)
-	}
 	return h, nil
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -282,7 +282,6 @@ type Operation struct {
 	ClientIP net.IP
 	ServerIP net.IP
 	SNI      string
-	AKI      SKI
 }
 
 func (o *Operation) String() string {

--- a/server/server.go
+++ b/server/server.go
@@ -33,18 +33,16 @@ type Keystore interface {
 // NewDefaultKeystore returns a new default memory-based static keystore.
 func NewDefaultKeystore() *DefaultKeystore {
 	return &DefaultKeystore{
-		skis:      make(map[gokeyless.SKI]crypto.Signer),
-		digests:   make(map[gokeyless.Digest]gokeyless.SKI),
-		validAKIs: make(map[gokeyless.SKI]akiSet),
+		skis:    make(map[gokeyless.SKI]crypto.Signer),
+		digests: make(map[gokeyless.Digest]gokeyless.SKI),
 	}
 }
 
 // DefaultKeystore is a simple in-memory key store.
 type DefaultKeystore struct {
 	sync.RWMutex
-	skis      map[gokeyless.SKI]crypto.Signer
-	digests   map[gokeyless.Digest]gokeyless.SKI
-	validAKIs map[gokeyless.SKI]akiSet
+	skis    map[gokeyless.SKI]crypto.Signer
+	digests map[gokeyless.Digest]gokeyless.SKI
 }
 
 // Add adds a new key to the server's internal repertoire.
@@ -60,10 +58,6 @@ func (keys *DefaultKeystore) Add(op *gokeyless.Operation, priv crypto.Signer) er
 
 	if digest, err := gokeyless.GetDigest(priv.Public()); err == nil {
 		keys.digests[digest] = ski
-	}
-
-	if op != nil {
-		keys.validAKIs[ski] = keys.validAKIs[ski].Add(op.AKI)
 	}
 
 	keys.skis[ski] = priv
@@ -122,24 +116,6 @@ func (keys *DefaultKeystore) LoadKeysFromDir(dir string, LoadKey func([]byte) (c
 		}
 		return nil
 	})
-}
-
-type akiSet []gokeyless.SKI
-
-func (akis akiSet) Contains(a gokeyless.SKI) bool {
-	for _, aki := range akis {
-		if aki.Equal(a) {
-			return true
-		}
-	}
-	return false
-}
-
-func (akis akiSet) Add(a gokeyless.SKI) akiSet {
-	if akis.Contains(a) {
-		return akis
-	}
-	return append(akis, a)
 }
 
 // Server is a Keyless Server capable of performing opaque key operations.


### PR DESCRIPTION
The AKI whitelist has apparent usage of allowing certain keys only to
answer operations from a certain keyless protocol client,
whose tls certificate issuer is on the list.

There are problems with current hashmap based implementation.

1. Currently whitelist is Add-only, which makes it impractical for
   whitelist CRUD.
2. Keyserver can have multiple keystores for each authorized keyless
   client. Each keystore has the agility of dynamic
   key loading. We can simply ask a corresponding keystore mapped by
   client cert issuer id: keyserver has the final say of whether a
   key is present for a given client.