### PR TITLE
ignore key digest in the official keyserver and client implementation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -200,14 +200,10 @@ func (c *Client) RegisterPublicKeyTemplate(server string, pub crypto.PublicKey, 
 		return nil, err
 	}
 
-	// digest is being deprecated, so it's ok to ignore error here
-	digest, _ := gokeyless.GetDigest(pub)
-
 	priv := PrivateKey{
 		public:   pub,
 		client:   c,
 		ski:      ski,
-		digest:   digest,
 		sni:      sni,
 		serverIP: serverIP,
 	}

--- a/client/keys.go
+++ b/client/keys.go
@@ -81,7 +81,6 @@ type PrivateKey struct {
 	public   crypto.PublicKey
 	client   *Client
 	ski      gokeyless.SKI
-	digest   gokeyless.Digest
 	clientIP net.IP
 	serverIP net.IP
 	sni      string
@@ -104,7 +103,6 @@ func (key *PrivateKey) execute(op gokeyless.Op, msg []byte) ([]byte, error) {
 		Opcode:   op,
 		Payload:  msg,
 		SKI:      key.ski,
-		Digest:   key.digest,
 		ClientIP: key.clientIP,
 		ServerIP: key.serverIP,
 		SNI:      key.sni,

--- a/server/server.go
+++ b/server/server.go
@@ -32,16 +32,14 @@ type Keystore interface {
 // NewDefaultKeystore returns a new default memory-based static keystore.
 func NewDefaultKeystore() *DefaultKeystore {
 	return &DefaultKeystore{
-		skis:    make(map[gokeyless.SKI]crypto.Signer),
-		digests: make(map[gokeyless.Digest]gokeyless.SKI),
+		skis: make(map[gokeyless.SKI]crypto.Signer),
 	}
 }
 
 // DefaultKeystore is a simple in-memory key store.
 type DefaultKeystore struct {
 	sync.RWMutex
-	skis    map[gokeyless.SKI]crypto.Signer
-	digests map[gokeyless.Digest]gokeyless.SKI
+	skis map[gokeyless.SKI]crypto.Signer
 }
 
 // Add adds a new key to the server's internal repertoire.
@@ -54,10 +52,6 @@ func (keys *DefaultKeystore) Add(op *gokeyless.Operation, priv crypto.Signer) er
 
 	keys.Lock()
 	defer keys.Unlock()
-
-	if digest, err := gokeyless.GetDigest(priv.Public()); err == nil {
-		keys.digests[digest] = ski
-	}
 
 	keys.skis[ski] = priv
 
@@ -78,14 +72,6 @@ func (keys *DefaultKeystore) Get(op *gokeyless.Operation) (crypto.Signer, bool) 
 		}
 	}
 
-	log.Debug("Couldn't look up key based on SKI, trying Digest.")
-	ski, ok := keys.digests[op.Digest]
-	if ok {
-		priv, found := keys.skis[ski]
-		if found {
-			return priv, found
-		}
-	}
 	log.Infof("Couldn't look up key for %s.", op)
 	return nil, false
 }


### PR DESCRIPTION
- we still keep digest in the protocol for backward compatibility
- we remove digest usage in server and client