### PR TITLE
conn.DoOperation (by its listen subroutine) should have timeout

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sync"
 	"time"
 
@@ -192,6 +193,8 @@ func (s *Server) handle(conn *gokeyless.Conn) {
 }
 
 func (s *Server) handleReq(conn *gokeyless.Conn, ch chan *gokeyless.Header) {
+	runtime.LockOSThread()
+
 	var connError error
 	for connError == nil {
 		h, more := <-ch


### PR DESCRIPTION
- the current communication model is as following:
  1. DoOperation writes a header, creates a channel and listen to the
     channel named by the Header ID.
  2. Each DoOperation will attempt a read, but the obtained Header by
     DoOperation call X may be for DoOperation call Y. And so X will
     still be waiting and hopefully another read attempt will return
     its result.
  3. DoOperation may forever hang on the channel. We need to timeout
     such hang.