### PR TITLE
DO NOT MERGE - remove Client.remotes

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -78,12 +78,13 @@ func signOpFromSignerOpts(key *PrivateKey, opts crypto.SignerOpts) gokeyless.Op 
 
 // PrivateKey represents a keyless-backed RSA/ECDSA private key.
 type PrivateKey struct {
-	public   crypto.PublicKey
-	client   *Client
-	ski      gokeyless.SKI
-	clientIP net.IP
-	serverIP net.IP
-	sni      string
+	public     crypto.PublicKey
+	client     *Client
+	ski        gokeyless.SKI
+	clientIP   net.IP
+	serverIP   net.IP
+	serverName string
+	sni        string
 }
 
 // Public returns the public key corresponding to the opaque private key.
@@ -94,7 +95,12 @@ func (key *PrivateKey) Public() crypto.PublicKey {
 // execute performs an opaque cryptographic operation on a server associated
 // with the key.
 func (key *PrivateKey) execute(op gokeyless.Op, msg []byte) ([]byte, error) {
-	conn, err := key.client.Dial(key.ski)
+	r, err := key.client.getRemote(key.serverName)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := r.Dial(key.client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The serverName -> *Remote mapping is a LRU, even if there won't be many
serverNames. Instead the SKI -> *Remote mapping is a simple map, from
which nothing is never removed. It will unavoidably grow in size the
more certs are observed.

One could obviously just use an LRU, but it got me thinking about why we
have that indirection anyway, when we could instead just stick the
serverName on the PrivateKey, and rely on the serverName -> *Remote LRU.

A lot of removed lines seem to suggest this simplifies things.

This is NOT a finished patch (haven't touched the tests), but it's
easier to talk over code.