### PR TITLE
Allow the server to not respond to some requests.

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -84,20 +84,17 @@ func healthchecker(conn *Conn) {
 
 	for {
 		time.Sleep(backoff.Duration())
-		if !conn.Conn.IsClosed() {
-			err := conn.Ping(nil)
-			if err != nil {
-				log.Debug("health check ping failed:", err)
-				// shut down the conn and remove it from the
-				// conn pool.
-				conn.Close()
-				return
-			}
 
-			log.Debug("start a new health check timer")
-		} else { // bail out
+		err := conn.Ping(nil)
+		if err != nil {
+			log.Debug("health check ping failed:", err)
+			// shut down the conn and remove it from the
+			// conn pool.
+			conn.Close()
 			return
 		}
+
+		log.Debug("start a new health check timer")
 	}
 }
 
@@ -231,7 +228,7 @@ func (s *singleRemote) Dial(c *Client) (*Conn, error) {
 	}
 
 	conn := connPool.Get(s.String())
-	if conn != nil && !conn.IsClosed() {
+	if conn != nil {
 		return conn, nil
 	}
 
@@ -256,6 +253,7 @@ func (s *singleRemote) Dial(c *Client) (*Conn, error) {
 		}
 
 		conn.Close()
+		connPool.Remove(s.String())
 	}()
 
 	return conn, nil

--- a/client/remote.go
+++ b/client/remote.go
@@ -246,6 +246,18 @@ func (s *singleRemote) Dial(c *Client) (*Conn, error) {
 	gconn := gokeyless.NewConn(inner)
 	conn = NewConn(s.String(), gconn)
 	connPool.Add(s.String(), conn)
+	go func() {
+		for {
+			err := conn.DoRead()
+			if err != nil {
+				log.Errorf("failed to read next header from %v: %v", s.String(), err)
+				break
+			}
+		}
+
+		conn.Close()
+	}()
+
 	return conn, nil
 }
 


### PR DESCRIPTION
Allowing the gokeyless server to panic w/o dying means that some requests will not get responses, and should timeout.

Imagine you call "DoOperation" twice. The first request causes a panic and the second is successful. The first DoOperation reads the second response and puts it into the channel and blocks on waiting for its own response, eventually timing out. The second DoOperation will block on reading another header from the socket. If a third DoOperation happens and gets a successful response, the second DoOperation will unblock and return its response, and the third DoOperation will hang until a fourth DoOperation. And on...