### PR TITLE
Remove Client.remotes

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -79,12 +79,13 @@ func signOpFromSignerOpts(key *PrivateKey, opts crypto.SignerOpts) gokeyless.Op 
 
 // PrivateKey represents a keyless-backed RSA/ECDSA private key.
 type PrivateKey struct {
-	public   crypto.PublicKey
-	client   *Client
-	ski      gokeyless.SKI
-	clientIP net.IP
-	serverIP net.IP
-	sni      string
+	public    crypto.PublicKey
+	client    *Client
+	ski       gokeyless.SKI
+	clientIP  net.IP
+	serverIP  net.IP
+	keyserver string
+	sni       string
 }
 
 // Public returns the public key corresponding to the opaque private key.
@@ -98,7 +99,12 @@ func (key *PrivateKey) execute(op gokeyless.Op, msg []byte) ([]byte, error) {
 	var result *gokeyless.Operation
 	// retry once if connection returned by remote Dial is problematic.
 	for attempts := 2; attempts > 0; attempts-- {
-		conn, err := key.client.Dial(key.ski)
+		r, err := key.client.getRemote(key.keyserver)
+		if err != nil {
+			return nil, err
+		}
+
+		conn, err := r.Dial(key.client)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gokeyless-cli-tester/gokeyless-cli-tester.go
+++ b/cmd/gokeyless-cli-tester/gokeyless-cli-tester.go
@@ -47,7 +47,7 @@ func main() {
 		log.Fatal(err)
 	}
 	c.Config.InsecureSkipVerify = insecureSkipVerify
-	privs, err := c.RegisterDir(keyserver, certDir, nil)
+	privs, err := c.ScanDir(keyserver, certDir, nil)
 	if err != nil {
 		log.Fatal("failed to load cert directory:", err)
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -27,13 +27,13 @@ type Tag byte
 const (
 	// TagCertificateDigest implies a SHA256 Digest of a key.
 	TagCertificateDigest Tag = 0x01
-	// TagServerName implies an SNI string.
+	// TagServerName implies server hostname (SNI) for the proxyed TLS server.
 	TagServerName Tag = 0x02
 	// TagClientIP implies an IPv4/6 address of the client connecting.
 	TagClientIP Tag = 0x03
 	// TagSubjectKeyIdentifier implies the Subject Key Identifier for the given key.
 	TagSubjectKeyIdentifier Tag = 0x04
-	// TagServerIP implies an IPv4/6 address of the proxying server.
+	// TagServerIP implies an IPv4/6 address of the proxyed TLS server.
 	TagServerIP Tag = 0x05
 	// TagOpcode implies an opcode describing operation to be performed OR operation status.
 	TagOpcode Tag = 0x11

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -61,7 +61,6 @@ func TestTLSProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.RegisterCert(serverAddr, cert.Leaf)
 
 	serverConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -244,7 +244,7 @@ func RunAPITests(in *testapi.Input, c *client.Client, testLen time.Duration, wor
 
 	for _, cert := range certs {
 		var privDec *client.Decrypter
-		priv, err := c.RegisterPublicKeyTemplate(in.Keyserver, cert.PublicKey, sni, serverIP)
+		priv, err := c.NewRemoteSignerTemplate(in.Keyserver, cert.PublicKey, sni, serverIP)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Client.remotes serves as a mapping from SKIs to remotes, which has no real usage
- remove client Dial(SKI) as we can directly dial with remote
- rename RegisterKey* to NewRemoteSigner*
- much cleaner tests