### PR TITLE
Make PingAll part of Remote interface, address #144

### DIFF
--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -127,7 +127,9 @@ func TestRemoteGroup(t *testing.T) {
 
 	// defqult remote group has one working remote and one that doesn't.
 	// PingAll should not hang.
-	r.PingAll(c)
+	r.PingAll(c, 1)
+	r.PingAll(c, 2)
+	r.PingAll(c, 3)
 }
 
 func TestUnixRemote(t *testing.T) {
@@ -197,7 +199,7 @@ func TestSlowServer(t *testing.T) {
 	c.DefaultRemote = g
 	t.Log("c.DefaultRemote size:", len(c.DefaultRemote.(*Group).remotes))
 
-	g.PingAll(c)
+	g.PingAll(c, 1)
 
 	// After ping checks, 1st remote must be the normal server.
 	firstRemote := g.remotes[0]

--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -124,6 +124,10 @@ func TestRemoteGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// defqult remote group has one working remote and one that doesn't.
+	// PingAll should not hang.
+	r.PingAll(c)
 }
 
 func TestUnixRemote(t *testing.T) {


### PR DESCRIPTION
- PingAll now uses channels and goroutines to collect ping measurements.
- rename item to mRemote