### PR TITLE
fix the read race on g.remotes

### DIFF
--- a/client/remote.go
+++ b/client/remote.go
@@ -421,7 +421,7 @@ func (g *Group) PingAll(c *Client, concurrency int) {
 		concurrency = 1
 	}
 	// ch receives all tested remote back
-	ch := make(chan mRemote, len(g.remotes))
+	ch := make(chan mRemote, len(remotes))
 	// jobQueue controls concurrency
 	jobQueue := make(chan bool, concurrency)
 	// fill the queue


### PR DESCRIPTION
see https://travis-ci.org/cloudflare/gokeyless/jobs/163552037
it's very benign race though, since len(g.remotes) seldom changes.