### PR TITLE
simplify NewServer

### DIFF
--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -55,10 +55,12 @@ func LoadKey(in []byte) (priv crypto.Signer, err error) {
 func TestMain(m *testing.M) {
 	var err error
 	// Setup keyless server
-	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA, serverAddr, socketAddr)
+	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA)
 	if err != nil {
 		log.Fatal(err)
 	}
+	s.Addr = serverAddr
+	s.UnixAddr = socketAddr
 
 	keys := server.NewDefaultKeystore()
 	keys.LoadKeysFromDir("testdata", LoadKey)
@@ -160,8 +162,7 @@ func TestBadRemote(t *testing.T) {
 
 func TestSlowServer(t *testing.T) {
 	// Setup a slow keyless server
-	s2, err := server.NewServerFromFile(serverCert, serverKey, keylessCA,
-		serverAddr, serverAddr)
+	s2, err := server.NewServerFromFile(serverCert, serverKey, keylessCA)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -76,10 +76,11 @@ func main() {
 		initializeServerCertAndKey()
 	}
 
-	s, err := server.NewServerFromFile(certFile, keyFile, caFile, net.JoinHostPort("", port), "")
+	s, err := server.NewServerFromFile(certFile, keyFile, caFile)
 	if err != nil {
 		log.Fatal("cannot start server:", err)
 	}
+	s.Addr = net.JoinHostPort("", port)
 
 	go func() { log.Fatal(s.ListenAndServe()) }()
 	go func() { log.Critical(s.MetricsListenAndServe(metricsAddr)) }()

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -81,10 +81,11 @@ func init() {
 
 	log.Level = log.LevelFatal
 
-	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA, serverAddr, "")
+	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA)
 	if err != nil {
 		log.Fatal(err)
 	}
+	s.Addr = serverAddr
 
 	keys := server.NewDefaultKeystore()
 	keys.LoadKeysFromDir("testdata", LoadKey)


### PR DESCRIPTION
- Server's exported 'Addr' and 'UnixAddr' fields can be safely decoupled
  from Server instance initialization