### PR TITLE
Add micro- and macro-benchmarks for throughput and latency

### DIFF
--- a/cmd/bench/internal/client/client.go
+++ b/cmd/bench/internal/client/client.go
@@ -1,0 +1,246 @@
+package client
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// A LatencyBucket represents one bucket in a latency histogram, recording the
+// number of requests which took in the range [From, Until].
+type LatencyBucket struct {
+	From, Until time.Duration
+	Count       uint64
+}
+
+// PrintHistogram prints a histogram of the given buckets to stdout. The buckets
+// are assumed to be non-overlapping intervals sorted in ascending order.
+func PrintHistogram(buckets []LatencyBucket) {
+	// To save screen space - especially because RunLatencyClients always returns
+	// a histogram whose largest bucket goes to the maximum time.Duration value -
+	// represent time.Duration(math.MaxInt64) as "-" instead of formatting the
+	// actual time.
+	durString := func(d time.Duration) string {
+		if d == time.Duration(math.MaxInt64) {
+			return "-"
+		}
+		return fmt.Sprint(d)
+	}
+
+	max := uint64(0)
+	firstNonzero := -1 // first bucket with Count > 0
+	lastNonzero := 0   // last bucket with Count > 0
+	maxFromLen := 0    // maximum length of string-formatted From field
+	maxUntilLen := 0   // maximum length of string-formatted Until field
+	for i, b := range buckets {
+		if b.Count > max {
+			max = b.Count
+		}
+		if b.Count > 0 {
+			if firstNonzero == -1 {
+				firstNonzero = i
+			}
+			lastNonzero = i
+
+			// Only count the length of the durations we're going to print - thus, do
+			// this logic inside this if block. The input could have 0-count buckets
+			// in between other non-zero-count buckets, but as long as the buckets are
+			// ascending in their from/until durations, the later buckets will always
+			// have equal- or greater-length duration strings than the current one, so
+			// skipping intermediate zero-count buckets is acceptable.
+			fromlen, untillen := len(durString(b.From)), len(durString(b.Until))
+			if fromlen > maxFromLen {
+				maxFromLen = fromlen
+			}
+			if untillen > maxUntilLen {
+				maxUntilLen = untillen
+			}
+		}
+	}
+
+	maxCountLen := len(fmt.Sprint(max))
+
+	fmtstr := fmt.Sprintf("[%%%vv, %%%vv) %%%vv | %%v\n", maxFromLen, maxUntilLen, maxCountLen)
+	fmax := float64(max)
+	for _, b := range buckets[firstNonzero : lastNonzero+1] {
+		perc := float64(b.Count) / fmax
+		height := int(perc * 70)
+		fmt.Printf(fmtstr, durString(b.From), durString(b.Until), b.Count, strings.Repeat("=", height))
+	}
+}
+
+// A BandwidthClient is a client used for bandwidth measurements. It must be
+// safe for Dispatch and Complete to be called concurrently from different
+// goroutines, although neither method needs to be safe for other concurrent
+// calls to itself. In other words, at most one call to each of the two methods
+// will be in progress at any given time.
+type BandwidthClient interface {
+	// Dispatch dispatches a new request, but does not wait for it to complete.
+	Dispatch()
+
+	// Complete waits for the next request to complete. It must wait for whatever
+	// request is the first to complete rather than waiting for a particular
+	// request.
+	Complete()
+}
+
+// RunBandwidthClients runs the provided BandwidthClients for the duration d.
+// For each client, two goroutines are spawned. One loops calling Dispatch, and
+// the other loops calling Complete. The total number of calls to Complete
+// (across all clients) is returned.
+//
+// Note that since only calls to Complete are recorded, it is possible (in fact,
+// quite likely) that there will be outstanding requests (created by Dispatch)
+// when the test quits. This means that the bandwidth estimate is a conservative
+// one. It also means that a very small value for d may skew results by making
+// it so that a large portion of the time is spent waiting for the first request
+// to return (effectively measuring request latency rather than steady state
+// bandwidth).
+func RunBandwidthClients(d time.Duration, clients ...BandwidthClient) uint64 {
+	if len(clients) == 0 {
+		panic("no clients")
+	}
+
+	// the marker will be atomically set to 1 when it's time for the goroutines to
+	// quit
+	var marker uint32
+	stop := func() bool { return atomic.LoadUint32(&marker) == 1 }
+
+	var counts = make([]uint64, len(clients))
+
+	var barrier, wg sync.WaitGroup
+	barrier.Add(1)
+	wg.Add(len(clients))
+	for i, c := range clients {
+		go func(i int, c BandwidthClient) {
+			barrier.Wait()
+			counts[i] = runBandwidthUntil(c, stop)
+			wg.Done()
+		}(i, c)
+	}
+
+	barrier.Done()
+	time.Sleep(d)
+	atomic.StoreUint32(&marker, 1)
+	wg.Wait()
+
+	sum := uint64(0)
+	for _, count := range counts {
+		sum += count
+	}
+	return sum
+}
+
+// runBandwidthUntil spawns two goroutines, with one repeatedly calling
+// c.Dispatch and the other repeatedly calling c.Complete. This continues until
+// stop returns true, at which point the goroutines quit and return the total
+// number of successfully completed requests. Some requests may be left
+// outstanding.
+func runBandwidthUntil(c BandwidthClient, stop func() bool) uint64 {
+	// We don't do any synchronization between the two goroutines, but the
+	// dispatch goroutine will eventually find stop() return false and will quit.
+	go func() {
+		for !stop() {
+			c.Dispatch()
+		}
+	}()
+
+	var count uint64
+	for !stop() {
+		c.Complete()
+		count++
+	}
+	return count
+}
+
+// A LatencyClient is a client used for latency measurements.
+type LatencyClient interface {
+	// Do executes a request and returns the duration.
+	Do() time.Duration
+}
+
+// FuncLatencyClient is a function that implements the LatencyClient interface.
+type FuncLatencyClient func() time.Duration
+
+// Do invokes f.
+func (f FuncLatencyClient) Do() time.Duration { return f() }
+
+var _ LatencyClient = FuncLatencyClient(nil)
+
+// RunLatencyClients runs the provided LatencyClients - each in its own
+// goroutine - for the duration d. It collects a histogram of the latencies
+// experienced by calls to Do. The lowest bucket will be from 0 to min, followed
+// by buckets whose width is given by step until max, followed by a bucket from
+// max to the maximum time.Duration.
+func RunLatencyClients(d time.Duration, min, max, step time.Duration, clients ...LatencyClient) []LatencyBucket {
+	if len(clients) == 0 {
+		panic("no clients")
+	}
+
+	// the marker will be atomically set to 1 when it's time for the goroutines to
+	// quit
+	var marker uint32
+	stop := func() bool { return atomic.LoadUint32(&marker) == 1 }
+
+	var histograms = make([][]LatencyBucket, len(clients))
+
+	var barrier, wg sync.WaitGroup
+	barrier.Add(1)
+	wg.Add(len(clients))
+	for i, c := range clients {
+		go func(i int, c LatencyClient) {
+			barrier.Wait()
+			histograms[i] = runLatencyUntil(c, min, max, step, stop)
+			wg.Done()
+		}(i, c)
+	}
+
+	barrier.Done()
+	time.Sleep(d)
+	atomic.StoreUint32(&marker, 1)
+	wg.Wait()
+
+	// since we got these histograms from runUntil, we know that they all have the
+	// same set and order of ranges, so we can trivially add them together to get
+	// the final answer. We arbitrarily pick histograms[0] to accumulate into.
+	buckets := histograms[0]
+	for _, bkts := range histograms[1:] {
+		for i, bkt := range bkts {
+			buckets[i].Count += bkt.Count
+		}
+	}
+	return buckets
+}
+
+func runLatencyUntil(c LatencyClient, bottom, top, skip time.Duration, stop func() bool) []LatencyBucket {
+	diff := top - bottom
+	nbuckets := int(diff / skip)
+	latencyCounts := make([]uint64, nbuckets+2)
+	for !stop() {
+		dur := c.Do()
+		if dur < bottom {
+			latencyCounts[0]++
+		} else if dur > top {
+			latencyCounts[nbuckets-1]++
+		} else {
+			bucketIdx := int((dur - bottom) / skip)
+			latencyCounts[bucketIdx]++
+		}
+	}
+
+	buckets := make([]LatencyBucket, nbuckets+2)
+	buckets[0].Until = bottom - 1
+	buckets[0].Count = latencyCounts[0]
+	buckets[nbuckets-1].From = top
+	buckets[nbuckets-1].Until = time.Duration(math.MaxInt64)
+	buckets[nbuckets-1].Count = latencyCounts[nbuckets-1]
+	for i := 0; i < nbuckets-2; i++ {
+		buckets[i+1].From = bottom + (time.Duration(i) * skip)
+		buckets[i+1].Until = bottom + ((time.Duration(i) + 1) * skip) - 1
+		buckets[i+1].Count = latencyCounts[i+1]
+	}
+	return buckets
+}

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,3 +1,5 @@
+// +build go1.8
+
 package main
 
 import (

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/cloudflare/gokeyless"
+	"github.com/cloudflare/gokeyless/client"
+	bclient "github.com/cloudflare/gokeyless/cmd/bench/internal/client"
+	"github.com/cloudflare/gokeyless/internal/test/params"
+)
+
+var (
+	certFileFlag string
+	keyFileFlag  string
+	caFileFlag   string
+	skiFlag      string
+	serverFlag   string
+	portFlag     uint64
+
+	bwFlag                     bool
+	gmpFlag                    int
+	workersFlag                int
+	durFlag                    time.Duration
+	minFlag, maxFlag, stepFlag time.Duration
+	pauseFlag                  time.Duration
+)
+
+func init() {
+	flag.StringVar(&certFileFlag, "cert", "../../client/testdata/client.pem", "file containing the client certificate")
+	flag.StringVar(&keyFileFlag, "key", "../../client/testdata/client-key.pem", "file containing the client key")
+	flag.StringVar(&caFileFlag, "ca", "../../client/testdata/ca.pem", "file containing the CA certificate")
+	flag.StringVar(&skiFlag, "ski", "D9C69B8E23ABBA7C26FD5D0E282F3DD679741036", "SKI of the key to request a signature from")
+	flag.StringVar(&serverFlag, "server", "localhost", "keyless server to connect to")
+	flag.Uint64Var(&portFlag, "port", 2407, "port to connect to the keyless server on")
+
+	flag.BoolVar(&bwFlag, "bandwidth", false, "perform a bandwidth test rather than a latency test")
+	flag.IntVar(&gmpFlag, "gmp", runtime.GOMAXPROCS(0), "override the default GOMAXPROCS")
+	flag.IntVar(&workersFlag, "workers", runtime.NumCPU(), "the number of worker goroutines to use")
+	flag.DurationVar(&durFlag, "duration", 10*time.Second, "the duration to run the test for")
+	flag.DurationVar(&minFlag, "histogram-min", 0, "minimum duration bucket for the histogram (default 0ns)")
+	flag.DurationVar(&maxFlag, "histogram-max", time.Millisecond, "maximum duration bucket for the histogram")
+	flag.DurationVar(&stepFlag, "histogram-step", 20*time.Microsecond, "histogram bucket width")
+	flag.DurationVar(&pauseFlag, "pause", 10*time.Millisecond, "for latency tests, the amount of time to wait between each request")
+}
+
+func main() {
+	flag.Parse()
+	if portFlag > uint64(math.MaxUint16) {
+		fmt.Fprintln(os.Stderr, "port out of range: must be in [0, 65535]")
+		flag.Usage()
+		os.Exit(2) // same code flag package uses for usage errors
+	}
+
+	skiBytes, err := hex.DecodeString(skiFlag)
+	if err != nil || len(skiBytes) != 20 {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not parse SKI as hex: %v\n", err)
+		} else {
+			fmt.Fprintln(os.Stderr, "SKI must be 20 bytes (40 hex characters)")
+		}
+		flag.Usage()
+		os.Exit(2) // same code flag package uses for usage errors
+	}
+	var ski gokeyless.SKI
+	copy(ski[:], skiBytes)
+
+	runtime.GOMAXPROCS(gmpFlag)
+
+	cli, err := client.NewClientFromFile(certFileFlag, keyFileFlag, caFileFlag)
+	if err != nil {
+		panic(err)
+	}
+
+	if bwFlag {
+		// Run a bandwidth test
+		var clients []bclient.BandwidthClient
+		for i := 0; i < workersFlag; i++ {
+			op := makeECDSASignOp(params.ECDSASHA512Params, ski)
+			c, err := makeBandwidthClientFromOp(cli, serverFlag, fmt.Sprint(portFlag), op)
+			if err != nil {
+				panic(err)
+			}
+			clients = append(clients, c)
+		}
+
+		count := bclient.RunBandwidthClients(durFlag, clients...)
+		fmt.Println("Total operations completed:", count)
+		fmt.Println("Average operation duration:", (durFlag)/time.Duration(count))
+	} else {
+		// Run a latency test
+		var clients []bclient.LatencyClient
+		for i := 0; i < workersFlag; i++ {
+			op := makeECDSASignOp(params.ECDSASHA512Params, ski)
+			c, err := makeLatencyClientFromOp(cli, serverFlag, fmt.Sprint(portFlag), op)
+			if err != nil {
+				panic(err)
+			}
+			clients = append(clients, c)
+		}
+
+		buckets := bclient.RunLatencyClients(durFlag, minFlag, maxFlag, stepFlag, clients...)
+		bclient.PrintHistogram(buckets)
+	}
+}
+
+type bwClient struct {
+	pkt  []byte
+	conn *tls.Conn
+}
+
+func (b *bwClient) Dispatch() {
+	_, err := b.conn.Write(b.pkt)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (b *bwClient) Complete() {
+	readPacket(b.conn)
+}
+
+func readPacket(conn *tls.Conn) {
+	var buf [8]byte
+	_, err := io.ReadFull(conn, buf[:])
+	if err != nil {
+		panic(err)
+	}
+
+	var pkt gokeyless.Packet
+	err = pkt.UnmarshalBinary(buf[:])
+	if err != nil {
+		panic(err)
+	}
+
+	body := make([]byte, pkt.Length)
+	_, err = io.ReadFull(conn, body)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func makeBandwidthClientFromOp(cli *client.Client, server, port string, op *gokeyless.Operation) (bclient.BandwidthClient, error) {
+	conn := dial(cli, server, port)
+	pkt, err := gokeyless.NewPacket(op).MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return &bwClient{
+		pkt:  pkt,
+		conn: conn,
+	}, nil
+}
+
+func makeLatencyClientFromOp(cli *client.Client, server, port string, op *gokeyless.Operation) (bclient.LatencyClient, error) {
+	conn := dial(cli, server, port)
+	pkt, err := gokeyless.NewPacket(op).MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return bclient.FuncLatencyClient(func() time.Duration {
+		t0 := time.Now()
+		_, err := conn.Write(pkt)
+		if err != nil {
+			panic(err)
+		}
+		readPacket(conn)
+		t1 := time.Now()
+		if t1.Before(t0) {
+			// Time went backwards (probably because somebody reset the clock - Go
+			// doens't yet support monotonic clocks). This test is obviously invalid.
+			panic("time moved backwards; the results of this test are untrustworthy")
+		}
+
+		time.Sleep(pauseFlag)
+
+		return t1.Sub(t0)
+	}), nil
+}
+
+// server must be the TLS name of the server and a resolvable domain name.
+func dial(cli *client.Client, server, port string) *tls.Conn {
+	config := cli.Config.Clone()
+	config.ServerName = server
+	conn, err := tls.Dial("tcp", server+":"+port, config)
+	if err != nil {
+		panic(err)
+	}
+	return conn
+}
+
+func makeRSASignOp(params params.RSASignParams, SKI gokeyless.SKI) *gokeyless.Operation {
+	return &gokeyless.Operation{
+		Opcode:  params.Opcode,
+		Payload: randBytes(params.PayloadSize),
+		SKI:     SKI,
+	}
+}
+
+func makeECDSASignOp(params params.ECDSASignParams, SKI gokeyless.SKI) *gokeyless.Operation {
+	return &gokeyless.Operation{
+		Opcode:  params.Opcode,
+		Payload: randBytes(params.PayloadSize),
+		SKI:     SKI,
+	}
+}
+
+func randBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := io.ReadFull(rand.New(rand.NewSource(time.Now().UnixNano())), b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -3,13 +3,13 @@
 package main
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"os"
 	"runtime"
 	"time"
@@ -244,7 +244,7 @@ func makeECDSASignOp(params params.ECDSASignParams, SKI gokeyless.SKI) *gokeyles
 
 func randBytes(n int) []byte {
 	b := make([]byte, n)
-	_, err := io.ReadFull(rand.New(rand.NewSource(time.Now().UnixNano())), b)
+	_, err := io.ReadFull(rand.Reader, b)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/vendor/github.com/joshlf/testutil/LICENSE
+++ b/cmd/vendor/github.com/joshlf/testutil/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016 The Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The names of the authors may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/vendor/github.com/joshlf/testutil/testutil.go
+++ b/cmd/vendor/github.com/joshlf/testutil/testutil.go
@@ -1,0 +1,173 @@
+// Copyright 2016 The Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package testutil provides utilities to make common testing tasks easier.
+//
+// For example, consider the task of creating a temporary file, and then
+// removing it. Normally, this might look something like:
+//  func TestTempFile(t *testing.T) {
+//      f, err := ioutil.TempFile("", "")
+//      if err != nil {
+//          t.Fatal("could not create temp file:", err)
+//      }
+//      err = os.Remove(f.Name())
+//      if err != nil {
+//          t.Fatalf("could not remove temp file:", err)
+//      }
+//  }
+//
+// Using testutil, this can be shortened to:
+//  func TestTempFile(t *testing.T) {
+//      f := testutil.MustTempFile(t, "", "")
+//      testutil.Must(t, os.Remove(f.Name()))
+//  }
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// TB is the interface common to testing.T
+// and testing.B. It is used instead of
+// testing.TB so that it can be satisfied
+// by types other than testing.T and
+// testing.B for internal testing purposes,
+// but can be treated by users of this
+// package as equivalent to testing.TB.
+type TB interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Skip(args ...interface{})
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Skipped() bool
+}
+
+// SrcDir attempts to figure out what source
+// file it is called from, and returns the
+// parent directory of that file. This can
+// be useful for tests which have local test
+// data, since commands such as
+//  go test ./...
+// can make it so that the current working
+// directory is not necessarily the same as
+// the source directory.
+func SrcDir() (dir string, ok bool) {
+	var f string
+	_, f, _, ok = runtime.Caller(1)
+	if !ok {
+		return
+	}
+	return filepath.Dir(f), true
+}
+
+// TODO(joshlf): Add ShouldXXX equivalents of each MustXXX function
+// that call t.Error instead of t.Fatal
+
+// MustTempFile attempts to create a temp file,
+// and logs the error to t.Fatalf if it fails.
+// The arguments dir and prefix behave as
+// documented in ioutil.TempFile.
+func MustTempFile(t TB, dir, prefix string) (f *os.File) {
+	f, err := ioutil.TempFile(dir, prefix)
+	must(t, err)
+	return f
+}
+
+// MustWriteTempFile attempts to create a temp
+// file and initialize it with the given body.
+// Unlike MustTempFile, it only returns the
+// name of the created file. If it fails, it
+// logs the error to t.Fatalf. The arguments
+// dir and prefix behave as documented in
+// ioutil.TempFile.
+func MustWriteTempFile(t TB, dir, prefix string, body []byte) string {
+	f, err := ioutil.TempFile(dir, prefix)
+	must(t, err)
+	name := f.Name()
+	_, err = f.Write(body)
+	must(t, err)
+	must(t, f.Sync())
+	must(t, f.Close())
+	return name
+}
+
+// MustTempDir attempts to create a temp directory,
+// and logs the error to t.Fatalf if it fails.
+// The arguments dir and prefix behave as
+// documented in ioutil.TempDir.
+func MustTempDir(t TB, dir, prefix string) (name string) {
+	name, err := ioutil.TempDir(dir, prefix)
+	must(t, err)
+	return name
+}
+
+// Must logs to t.Fatalf if err != nil.
+func Must(t TB, err error) {
+	must(t, err)
+}
+
+// MustPrefix is like Must, except that if it
+// logs to t.Fatalf, the given prefix is prepended
+// to the output.
+func MustPrefix(t TB, prefix string, err error) {
+	if err != nil {
+		nfatalf(t, 1, prefix+": %v", err)
+	}
+}
+
+// MustError logs to t.Fatalf if err == nil
+// or if err.Error() != expect.
+func MustError(t TB, expect string, err error) {
+	if err == nil {
+		nfatalf(t, 1, "unexpected nil error")
+	}
+	if err.Error() != expect {
+		nfatalf(t, 1, "unexpected error: got %q; want %q", err, expect)
+	}
+}
+
+// MustErrorPrefix is like MustError, except that
+// if it logs to t.Fatalf, the given prefix is
+// prepended to the output.
+func MustErrorPrefix(t TB, prefix, expect string, err error) {
+	if err == nil {
+		nfatalf(t, 1, prefix+": unexpected nil error")
+	}
+	if err.Error() != expect {
+		nfatalf(t, 1, prefix+": unexpected error: got %q; want %q", err, expect)
+	}
+}
+
+// must is equivalent to Must, except that it assumes
+// that it is called from a function defined in this
+// package, which is in turn called by a user of this
+// package. It prefixes any errors reported with the
+// original caller's file and line number.
+func must(t TB, err error) {
+	if err != nil {
+		nfatalf(t, 2, "%v", err)
+	}
+}
+
+// nfatalf calls t.Fatalf, but prepends the file and
+// line number of the caller's nth ancestor.
+func nfatalf(t TB, n int, format string, args ...interface{}) {
+	_, file, line, ok := runtime.Caller(n + 1)
+	if !ok {
+		t.Fatalf("unknown file/line: "+format, args...)
+	}
+	file = filepath.Base(file)
+	t.Fatalf("%v:%v: "+format, append([]interface{}{file, line}, args...)...)
+}

--- a/cmd/vendor/manifest
+++ b/cmd/vendor/manifest
@@ -4,6 +4,7 @@
 		{
 			"importpath": "github.com/beorn7/perks/quantile",
 			"repository": "https://github.com/beorn7/perks",
+			"vcs": "",
 			"revision": "b965b613227fddccbfffe13eae360ed3fa822f8d",
 			"branch": "master",
 			"path": "/quantile"
@@ -11,6 +12,7 @@
 		{
 			"importpath": "github.com/cloudflare/cfssl/crypto/pkcs7",
 			"repository": "https://github.com/cloudflare/cfssl",
+			"vcs": "",
 			"revision": "0ec15debaac95e372ef331c76d80e8aa4887ae8e",
 			"branch": "master",
 			"path": "/crypto/pkcs7"
@@ -18,6 +20,7 @@
 		{
 			"importpath": "github.com/cloudflare/cfssl/csr",
 			"repository": "https://github.com/cloudflare/cfssl",
+			"vcs": "",
 			"revision": "0ec15debaac95e372ef331c76d80e8aa4887ae8e",
 			"branch": "master",
 			"path": "/csr"
@@ -25,6 +28,7 @@
 		{
 			"importpath": "github.com/cloudflare/cfssl/errors",
 			"repository": "https://github.com/cloudflare/cfssl",
+			"vcs": "",
 			"revision": "0ec15debaac95e372ef331c76d80e8aa4887ae8e",
 			"branch": "master",
 			"path": "/errors"
@@ -32,20 +36,15 @@
 		{
 			"importpath": "github.com/cloudflare/cfssl/helpers",
 			"repository": "https://github.com/cloudflare/cfssl",
+			"vcs": "",
 			"revision": "48ec0e4dc1fdb86e5a1d6d33c1d36cf0990a39b4",
 			"branch": "master",
 			"path": "/helpers"
 		},
 		{
-			"importpath": "github.com/cloudflare/cfssl/helpers/derhelpers",
-			"repository": "https://github.com/cloudflare/cfssl",
-			"revision": "0ec15debaac95e372ef331c76d80e8aa4887ae8e",
-			"branch": "master",
-			"path": "/helpers/derhelpers"
-		},
-		{
 			"importpath": "github.com/cloudflare/cfssl/log",
 			"repository": "https://github.com/cloudflare/cfssl",
+			"vcs": "",
 			"revision": "737cb1da8f508eb43b50bde3c3ccbbf2f8050deb",
 			"branch": "master",
 			"path": "/log"
@@ -53,13 +52,23 @@
 		{
 			"importpath": "github.com/golang/protobuf/proto",
 			"repository": "https://github.com/golang/protobuf",
+			"vcs": "",
 			"revision": "3c84672111d91bb5ac31719e112f9f7126a0e26e",
 			"branch": "master",
 			"path": "/proto"
 		},
 		{
+			"importpath": "github.com/joshlf/testutil",
+			"repository": "https://github.com/joshlf/testutil",
+			"vcs": "git",
+			"revision": "b5d8aa79d93d48182827b15fe02ba8678687351e",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
 			"repository": "https://github.com/matttproud/golang_protobuf_extensions",
+			"vcs": "",
 			"revision": "d0c3fe89de86839aecf2e0579c40ba3bb336a453",
 			"branch": "master",
 			"path": "/pbutil"
@@ -67,12 +76,14 @@
 		{
 			"importpath": "github.com/miekg/dns",
 			"repository": "https://github.com/miekg/dns",
+			"vcs": "",
 			"revision": "297a77c2fb5ebf0f261733e3c03f0c3bb9fdd917",
 			"branch": "master"
 		},
 		{
 			"importpath": "github.com/prometheus/client_golang/prometheus",
 			"repository": "https://github.com/prometheus/client_golang",
+			"vcs": "",
 			"revision": "18acf9993a863f4c4b40612e19cdd243e7c86831",
 			"branch": "master",
 			"path": "/prometheus"
@@ -80,6 +91,7 @@
 		{
 			"importpath": "github.com/prometheus/client_model/go",
 			"repository": "https://github.com/prometheus/client_model",
+			"vcs": "",
 			"revision": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6",
 			"branch": "master",
 			"path": "/go"
@@ -87,6 +99,7 @@
 		{
 			"importpath": "github.com/prometheus/common/expfmt",
 			"repository": "https://github.com/prometheus/common",
+			"vcs": "",
 			"revision": "23070236b1ebff452f494ae831569545c2b61d26",
 			"branch": "master",
 			"path": "/expfmt"
@@ -94,6 +107,7 @@
 		{
 			"importpath": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
 			"repository": "https://github.com/prometheus/common",
+			"vcs": "",
 			"revision": "23070236b1ebff452f494ae831569545c2b61d26",
 			"branch": "master",
 			"path": "/internal/bitbucket.org/ww/goautoneg"
@@ -101,6 +115,7 @@
 		{
 			"importpath": "github.com/prometheus/common/model",
 			"repository": "https://github.com/prometheus/common",
+			"vcs": "",
 			"revision": "23070236b1ebff452f494ae831569545c2b61d26",
 			"branch": "master",
 			"path": "/model"
@@ -108,12 +123,14 @@
 		{
 			"importpath": "github.com/prometheus/procfs",
 			"repository": "https://github.com/prometheus/procfs",
+			"vcs": "",
 			"revision": "406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8",
 			"branch": "master"
 		},
 		{
 			"importpath": "golang.org/x/crypto/pkcs12",
 			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "",
 			"revision": "3760e016850398b85094c4c99e955b8c3dea5711",
 			"branch": "master",
 			"path": "/pkcs12"

--- a/internal/test/params/params.go
+++ b/internal/test/params/params.go
@@ -1,0 +1,53 @@
+// Package params provides parameters useful in testing cryptographic
+// operations.
+package params
+
+import (
+	"crypto"
+	"crypto/elliptic"
+	"crypto/rsa"
+
+	"github.com/cloudflare/gokeyless"
+)
+
+// RSASignParams represents a set of parameters to an RSA signing operation.
+type RSASignParams struct {
+	Opcode      gokeyless.Op      // The Keyless protocol opcode for this operation
+	Bits        int               // The size of the key in bits
+	Opts        crypto.SignerOpts // Options to the signing function
+	PayloadSize int               // The size of the payload to be signed
+}
+
+// NOTE: RSAMD5SHA1Params' PayloadSize is 36 because that's the sum of 16
+// (the size of an MD5 hash) and 20 (the size of a SHA1 hash).
+
+var (
+	RSAMD5SHA1Params   = RSASignParams{Opcode: gokeyless.OpRSASignMD5SHA1, Opts: crypto.MD5SHA1, PayloadSize: 36}
+	RSASHA1Params      = RSASignParams{Opcode: gokeyless.OpRSASignSHA1, Opts: crypto.SHA1, PayloadSize: 20}
+	RSASHA224Params    = RSASignParams{Opcode: gokeyless.OpRSASignSHA224, Opts: crypto.SHA224, PayloadSize: 28}
+	RSASHA256Params    = RSASignParams{Opcode: gokeyless.OpRSASignSHA256, Opts: crypto.SHA256, PayloadSize: 32}
+	RSASHA384Params    = RSASignParams{Opcode: gokeyless.OpRSASignSHA384, Opts: crypto.SHA384, PayloadSize: 48}
+	RSASHA512Params    = RSASignParams{Opcode: gokeyless.OpRSASignSHA512, Opts: crypto.SHA512, PayloadSize: 64}
+	RSAPSSSHA256Params = RSASignParams{Opcode: gokeyless.OpRSAPSSSignSHA256, Opts: optsToRSAPSS(crypto.SHA256), PayloadSize: 32}
+	RSAPSSSHA384Params = RSASignParams{Opcode: gokeyless.OpRSAPSSSignSHA384, Opts: optsToRSAPSS(crypto.SHA384), PayloadSize: 48}
+	RSAPSSSHA512Params = RSASignParams{Opcode: gokeyless.OpRSAPSSSignSHA512, Opts: optsToRSAPSS(crypto.SHA512), PayloadSize: 64}
+)
+
+func optsToRSAPSS(opts crypto.SignerOpts) crypto.SignerOpts {
+	return &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: opts.HashFunc()}
+}
+
+// ECDSASignParams represents a set of parameters to an ECDSA signing operation.
+type ECDSASignParams struct {
+	Opcode      gokeyless.Op      // The Keyless protocol opcode for this operation
+	Curve       elliptic.Curve    // The ECDSA curve to use for signing
+	Opts        crypto.SignerOpts // Options to the signing function
+	PayloadSize int               // The size of the payload to be signed
+}
+
+var (
+	ECDSASHA224Params = ECDSASignParams{Opcode: gokeyless.OpECDSASignSHA224, Curve: elliptic.P256(), Opts: crypto.SHA224, PayloadSize: 28}
+	ECDSASHA256Params = ECDSASignParams{Opcode: gokeyless.OpECDSASignSHA256, Curve: elliptic.P256(), Opts: crypto.SHA256, PayloadSize: 32}
+	ECDSASHA384Params = ECDSASignParams{Opcode: gokeyless.OpECDSASignSHA384, Curve: elliptic.P384(), Opts: crypto.SHA384, PayloadSize: 48}
+	ECDSASHA512Params = ECDSASignParams{Opcode: gokeyless.OpECDSASignSHA512, Curve: elliptic.P521(), Opts: crypto.SHA512, PayloadSize: 64}
+)

--- a/server/microbench_test.go
+++ b/server/microbench_test.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/cloudflare/gokeyless/internal/test/params"
+	"github.com/joshlf/testutil"
+)
+
+// mustReadFull tries to read from r until b is fully populated, calling
+// tb.Fatal on failure.
+func mustReadFull(tb testutil.TB, r io.Reader, b []byte) {
+	_, err := io.ReadFull(r, b)
+	testutil.MustPrefix(tb, "could not perform full read", err)
+}
+
+func benchSign(b *testing.B, key crypto.Signer, rnd io.Reader, payload []byte, opts crypto.SignerOpts) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := key.Sign(rnd, payload, opts)
+		testutil.MustPrefix(b, "could not create signature", err)
+	}
+}
+
+func benchSignParallel(b *testing.B, key crypto.Signer, rnd io.Reader, payload []byte, opts crypto.SignerOpts) {
+	// The barrier is used to ensure that goroutines only start running once we
+	// release them.
+	var barrier, wg sync.WaitGroup
+	barrier.Add(1)
+	wg.Add(runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			barrier.Wait()
+			for i := 0; i < b.N; i++ {
+				_, err := key.Sign(rnd, payload, opts)
+				testutil.MustPrefix(b, "could not create signature", err)
+			}
+			wg.Done()
+		}()
+	}
+
+	b.ResetTimer()
+	barrier.Done()
+	wg.Wait()
+}
+
+type countingReader int
+
+func (c *countingReader) Read(b []byte) (n int, err error) {
+	n, err = rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	*c += countingReader(n)
+	return n, err
+}
+
+// benchRandFor calls op once with a custom reader to determine how many bytes
+// of randomness are requested. Then, it benchmarks reading that many bytes from
+// "crypto/rand".Reader.
+func benchRandFor(b *testing.B, op func(rnd io.Reader)) {
+	var c countingReader
+	op(&c)
+	buf := make([]byte, int(c))
+	b.SetBytes(int64(c))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := io.ReadFull(rand.Reader, buf)
+		testutil.MustPrefix(b, "could not read crypto/rand.Reader", err)
+	}
+}
+
+// benchRandParallelFor is like benchRandFor, but it spawns one goroutine per
+// CPU core in order to benchmark the effects of contention on the /dev/urandom
+// subsystem. It reports the speed for a single operation (in other words, if
+// four cores are used, it will not report a number four times as high as if
+// one core were used, but rather (in the highest-performance case) the same
+// number).
+func benchRandParallelFor(b *testing.B, op func(rnd io.Reader)) {
+	var c countingReader
+	op(&c)
+	b.SetBytes(int64(c))
+
+	// The barrier is used to ensure that goroutines only start running once we
+	// release them.
+	var barrier, wg sync.WaitGroup
+	barrier.Add(1)
+	wg.Add(runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		buf := make([]byte, int(c))
+		go func(buf []byte) {
+			barrier.Wait()
+			for i := 0; i < b.N; i++ {
+				_, err := io.ReadFull(rand.Reader, buf)
+				testutil.MustPrefix(b, "could not read crypto/rand.Reader", err)
+			}
+			wg.Done()
+		}(buf)
+	}
+
+	b.ResetTimer()
+	barrier.Done()
+	wg.Wait()
+}
+
+// benchRandForSignRSA is an RSA signature-specific wrapper around benchRandFor.
+func benchRandForSignRSA(b *testing.B, params params.RSASignParams) {
+	key, payload := prepareRSASigner(b, 2048, params.PayloadSize)
+	op := func(rnd io.Reader) { key.Sign(rnd, payload, params.Opts) }
+	benchRandFor(b, op)
+}
+
+// benchRandParallelForSignRSA is an RSA signature-specific wrapper around
+// benchRandFor.
+func benchRandParallelForSignRSA(b *testing.B, params params.RSASignParams) {
+	key, payload := prepareRSASigner(b, 2048, params.PayloadSize)
+	op := func(rnd io.Reader) { key.Sign(rnd, payload, params.Opts) }
+	benchRandParallelFor(b, op)
+}
+
+func benchSignRSA(b *testing.B, params params.RSASignParams) {
+	key, payload := prepareRSASigner(b, 2048, params.PayloadSize)
+	benchSign(b, key, rand.Reader, payload[:], params.Opts)
+}
+
+func benchSignParallelRSA(b *testing.B, params params.RSASignParams) {
+	key, payload := prepareRSASigner(b, 2048, params.PayloadSize)
+	benchSignParallel(b, key, rand.Reader, payload[:], params.Opts)
+}
+
+// prepareRSASigner performs the boilerplate of generating values needed to
+// benchmark RSA signatures.
+func prepareRSASigner(b *testing.B, bits int, payloadsize int) (key crypto.Signer, payload []byte) {
+	k, err := rsa.GenerateKey(rand.Reader, bits)
+	testutil.MustPrefix(b, "could not generate RSA key", err)
+	payload = make([]byte, payloadsize)
+	mustReadFull(b, rand.Reader, payload[:])
+	return k, payload
+}
+
+// benchRandForSignECDSA is an ECDSA signature-specific wrapper around benchRandFor.
+func benchRandForSignECDSA(b *testing.B, params params.ECDSASignParams) {
+	key, payload := prepareECDSASigner(b, params.Curve, params.PayloadSize)
+	op := func(rnd io.Reader) { key.Sign(rnd, payload, params.Opts) }
+	benchRandFor(b, op)
+}
+
+// benchRandParallelForSignECDSA is an ECDSA signature-specific wrapper around
+// benchRandParallelFor.
+func benchRandParallelForSignECDSA(b *testing.B, params params.ECDSASignParams) {
+	key, payload := prepareECDSASigner(b, params.Curve, params.PayloadSize)
+	op := func(rnd io.Reader) { key.Sign(rnd, payload, params.Opts) }
+	benchRandParallelFor(b, op)
+}
+
+func benchSignECDSA(b *testing.B, params params.ECDSASignParams) {
+	key, payload := prepareECDSASigner(b, params.Curve, params.PayloadSize)
+	benchSign(b, key, rand.Reader, payload[:], params.Opts)
+}
+
+func benchSignParallelECDSA(b *testing.B, params params.ECDSASignParams) {
+	key, payload := prepareECDSASigner(b, params.Curve, params.PayloadSize)
+	benchSignParallel(b, key, rand.Reader, payload[:], params.Opts)
+}
+
+// prepareECDSASigner performs the boilerplate of generating values needed to
+// benchmark ECDSA signatures.
+func prepareECDSASigner(b *testing.B, curve elliptic.Curve, payloadsize int) (key crypto.Signer, payload []byte) {
+	k, err := ecdsa.GenerateKey(curve, rand.Reader)
+	testutil.MustPrefix(b, "could not generate ECDSA key", err)
+	payload = make([]byte, payloadsize)
+	mustReadFull(b, rand.Reader, payload[:])
+	return k, payload
+}
+
+func BenchmarkCryptoRand(b *testing.B) {
+	buf := make([]byte, b.N)
+	b.SetBytes(1)
+	b.ResetTimer()
+	io.ReadFull(rand.Reader, buf)
+}
+
+func BenchmarkSignRSAMD5SHA1(b *testing.B)   { benchSignRSA(b, params.RSAMD5SHA1Params) }
+func BenchmarkSignRSASHA1(b *testing.B)      { benchSignRSA(b, params.RSASHA1Params) }
+func BenchmarkSignRSASHA224(b *testing.B)    { benchSignRSA(b, params.RSASHA224Params) }
+func BenchmarkSignRSASHA256(b *testing.B)    { benchSignRSA(b, params.RSASHA256Params) }
+func BenchmarkSignRSASHA384(b *testing.B)    { benchSignRSA(b, params.RSASHA384Params) }
+func BenchmarkSignRSASHA512(b *testing.B)    { benchSignRSA(b, params.RSASHA512Params) }
+func BenchmarkSignRSAPSSSHA256(b *testing.B) { benchSignRSA(b, params.RSAPSSSHA256Params) }
+func BenchmarkSignRSAPSSSHA384(b *testing.B) { benchSignRSA(b, params.RSAPSSSHA384Params) }
+func BenchmarkSignRSAPSSSHA512(b *testing.B) { benchSignRSA(b, params.RSAPSSSHA512Params) }
+func BenchmarkSignECDSASHA224(b *testing.B)  { benchSignECDSA(b, params.ECDSASHA224Params) }
+func BenchmarkSignECDSASHA256(b *testing.B)  { benchSignECDSA(b, params.ECDSASHA256Params) }
+func BenchmarkSignECDSASHA384(b *testing.B)  { benchSignECDSA(b, params.ECDSASHA384Params) }
+func BenchmarkSignECDSASHA512(b *testing.B)  { benchSignECDSA(b, params.ECDSASHA512Params) }
+
+func BenchmarkSignParallelRSAMD5SHA1(b *testing.B) { benchSignParallelRSA(b, params.RSAMD5SHA1Params) }
+func BenchmarkSignParallelRSASHA1(b *testing.B)    { benchSignParallelRSA(b, params.RSASHA1Params) }
+func BenchmarkSignParallelRSASHA224(b *testing.B)  { benchSignParallelRSA(b, params.RSASHA224Params) }
+func BenchmarkSignParallelRSASHA256(b *testing.B)  { benchSignParallelRSA(b, params.RSASHA256Params) }
+func BenchmarkSignParallelRSASHA384(b *testing.B)  { benchSignParallelRSA(b, params.RSASHA384Params) }
+func BenchmarkSignParallelRSASHA512(b *testing.B)  { benchSignParallelRSA(b, params.RSASHA512Params) }
+func BenchmarkSignParallelRSAPSSSHA256(b *testing.B) {
+	benchSignParallelRSA(b, params.RSAPSSSHA256Params)
+}
+func BenchmarkSignParallelRSAPSSSHA384(b *testing.B) {
+	benchSignParallelRSA(b, params.RSAPSSSHA384Params)
+}
+func BenchmarkSignParallelRSAPSSSHA512(b *testing.B) {
+	benchSignParallelRSA(b, params.RSAPSSSHA512Params)
+}
+func BenchmarkSignParallelECDSASHA224(b *testing.B) {
+	benchSignParallelECDSA(b, params.ECDSASHA224Params)
+}
+func BenchmarkSignParallelECDSASHA256(b *testing.B) {
+	benchSignParallelECDSA(b, params.ECDSASHA256Params)
+}
+func BenchmarkSignParallelECDSASHA384(b *testing.B) {
+	benchSignParallelECDSA(b, params.ECDSASHA384Params)
+}
+func BenchmarkSignParallelECDSASHA512(b *testing.B) {
+	benchSignParallelECDSA(b, params.ECDSASHA512Params)
+}
+
+func BenchmarkRandForSignRSAMD5SHA1(b *testing.B)   { benchRandForSignRSA(b, params.RSAMD5SHA1Params) }
+func BenchmarkRandForSignRSASHA1(b *testing.B)      { benchRandForSignRSA(b, params.RSASHA1Params) }
+func BenchmarkRandForSignRSASHA224(b *testing.B)    { benchRandForSignRSA(b, params.RSASHA224Params) }
+func BenchmarkRandForSignRSASHA256(b *testing.B)    { benchRandForSignRSA(b, params.RSASHA256Params) }
+func BenchmarkRandForSignRSASHA384(b *testing.B)    { benchRandForSignRSA(b, params.RSASHA384Params) }
+func BenchmarkRandForSignRSASHA512(b *testing.B)    { benchRandForSignRSA(b, params.RSASHA512Params) }
+func BenchmarkRandForSignRSAPSSSHA256(b *testing.B) { benchRandForSignRSA(b, params.RSAPSSSHA256Params) }
+func BenchmarkRandForSignRSAPSSSHA384(b *testing.B) { benchRandForSignRSA(b, params.RSAPSSSHA384Params) }
+func BenchmarkRandForSignRSAPSSSHA512(b *testing.B) { benchRandForSignRSA(b, params.RSAPSSSHA512Params) }
+func BenchmarkRandForSignECDSASHA224(b *testing.B)  { benchRandForSignECDSA(b, params.ECDSASHA224Params) }
+func BenchmarkRandForSignECDSASHA256(b *testing.B)  { benchRandForSignECDSA(b, params.ECDSASHA256Params) }
+func BenchmarkRandForSignECDSASHA384(b *testing.B)  { benchRandForSignECDSA(b, params.ECDSASHA384Params) }
+func BenchmarkRandForSignECDSASHA512(b *testing.B)  { benchRandForSignECDSA(b, params.ECDSASHA512Params) }
+
+func BenchmarkRandParallelForSignRSAMD5SHA1(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSAMD5SHA1Params)
+}
+func BenchmarkRandParallelForSignRSASHA1(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSASHA1Params)
+}
+func BenchmarkRandParallelForSignRSASHA224(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSASHA224Params)
+}
+func BenchmarkRandParallelForSignRSASHA256(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSASHA256Params)
+}
+func BenchmarkRandParallelForSignRSASHA384(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSASHA384Params)
+}
+func BenchmarkRandParallelForSignRSASHA512(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSASHA512Params)
+}
+func BenchmarkRandParallelForSignRSAPSSSHA256(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSAPSSSHA256Params)
+}
+func BenchmarkRandParallelForSignRSAPSSSHA384(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSAPSSSHA384Params)
+}
+func BenchmarkRandParallelForSignRSAPSSSHA512(b *testing.B) {
+	benchRandParallelForSignRSA(b, params.RSAPSSSHA512Params)
+}
+func BenchmarkRandParallelForSignECDSASHA224(b *testing.B) {
+	benchRandParallelForSignECDSA(b, params.ECDSASHA224Params)
+}
+func BenchmarkRandParallelForSignECDSASHA256(b *testing.B) {
+	benchRandParallelForSignECDSA(b, params.ECDSASHA256Params)
+}
+func BenchmarkRandParallelForSignECDSASHA384(b *testing.B) {
+	benchRandParallelForSignECDSA(b, params.ECDSASHA384Params)
+}
+func BenchmarkRandParallelForSignECDSASHA512(b *testing.B) {
+	benchRandParallelForSignECDSA(b, params.ECDSASHA512Params)
+}


### PR DESCRIPTION
This PR adds some microbenchmarks for cryptographic computations and a macrobenchmarking tool to measure latency and bandwidth characteristics of a Keyless server.