### PR TITLE
Revert "Revert "reduce tcp listener's connection timeout to restrict …

### DIFF
--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -173,7 +173,7 @@ func TestSlowServer(t *testing.T) {
 	sl := slowListener{l}
 
 	go func() {
-		if err := s2.Serve(&sl); err != nil {
+		if err := s2.Serve(&sl, time.Second*30); err != nil {
 			t.Fatal(err)
 		}
 	}()


### PR DESCRIPTION
…goroutine growth""

This reverts commit 7fb7200eccdd5988f35c2bd4a6c1be4c5af9a299.

The go=1.6 tests fail because it looks like a dependency was rewritten to use contexts. Is that a blocker?