### PR TITLE
Background workers use less memory, CPU.

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -368,7 +368,7 @@ type Operation struct {
 }
 
 func (o *Operation) String() string {
-	return fmt.Sprintf("[Opcode: %02x, SKI: %02x, Digest: %02x, Client IP: %s, Server IP: %s, SNI: %s]",
+	return fmt.Sprintf("[Opcode: %02x, SKI: %v, Digest: %02x, Client IP: %s, Server IP: %s, SNI: %s]",
 		o.Opcode,
 		o.SKI,
 		o.Digest,

--- a/server/server.go
+++ b/server/server.go
@@ -402,7 +402,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 	return makeRespondResponse(pkt.ID, sig)
 }
 
-const randBufferLen = 1024 * 1024
+const randBufferLen = 1024
 
 type ecdsaWorker struct {
 	buf  *buf_ecdsa.SyncRandBuffer

--- a/server/server.go
+++ b/server/server.go
@@ -95,7 +95,7 @@ func (keys *DefaultKeystore) Add(op *protocol.Operation, priv crypto.Signer) err
 
 	keys.skis[ski] = priv
 
-	log.Debugf("add key with SKI: %02x", ski)
+	log.Debugf("add key with SKI: %v", ski)
 	return nil
 }
 


### PR DESCRIPTION
The ECDSA buffering currently uses a lot of memory imo (134MB), and stays at 100% CPU for several seconds/minutes while it is populating the buffer.