### PR TITLE
Move blacklist additions to debug loglevel.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -91,7 +91,7 @@ func NewAddrSet() AddrSet { return AddrSet{m: make(map[string]bool)} }
 
 // Add adds an addr to the set of addresses.
 func (as AddrSet) Add(addr net.Addr) {
-	log.Infof("add to blacklist addr set: %s", addr)
+	log.Debugf("add to blacklist addr set: %s", addr)
 	as.m[addr.String()] = true
 }
 


### PR DESCRIPTION
It's just really noisy on machines with a lot of addresses, and I haven't seen fit to use it for anything.