### PR TITLE
server: Add metrics for total request duration, request opcodes

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -5,23 +5,40 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/gokeyless/protocol"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type statistics struct {
-	requestDuration     prometheus.Summary
-	requestsInvalid     prometheus.Counter
-	connFailures        prometheus.Counter
-	queuedECDSARequests prometheus.Gauge
-	queuedOtherRequests prometheus.Gauge
+	requestExecDuration          prometheus.Summary
+	requestTotalDuration         prometheus.Summary
+	requestExecDurationByOpcode  *prometheus.SummaryVec
+	requestTotalDurationByOpcode *prometheus.SummaryVec
+	requestsInvalid              prometheus.Counter
+	connFailures                 prometheus.Counter
+	queuedECDSARequests          prometheus.Gauge
+	queuedOtherRequests          prometheus.Gauge
+	requestOpcodes               *prometheus.CounterVec
 }
 
 func newStatistics() *statistics {
-	stats := &statistics{
-		requestDuration: prometheus.NewSummary(prometheus.SummaryOpts{
-			Name: "keyless_request_duration",
-			Help: "Requests duration summary in seconds.",
+	return &statistics{
+		requestExecDuration: prometheus.NewSummary(prometheus.SummaryOpts{
+			Name: "keyless_request_execution_duration",
+			Help: "Time to execute a request not including time in queues.",
 		}),
+		requestTotalDuration: prometheus.NewSummary(prometheus.SummaryOpts{
+			Name: "keyless_request_total_duration",
+			Help: "Total time to satisfy a request including time in queues.",
+		}),
+		requestExecDurationByOpcode: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "keyless_request_exec_duration_per_opcode",
+			Help: "Time to execute a request not including time in queues, broken down by opcode.",
+		}, []string{"opcode"}),
+		requestTotalDurationByOpcode: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "keyless_request_total_duration_per_opcode",
+			Help: "Total time to satisfy a request including time in queues, broken down by opcode.",
+		}, []string{"opcode"}),
 		requestsInvalid: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "keyless_requests_invalid",
 			Help: "Number of invalid requests.",
@@ -38,14 +55,17 @@ func newStatistics() *statistics {
 			Name: "keyless_queued_other_requests",
 			Help: "Number of queued non-ECDSA requests waiting to be executed.",
 		}),
+		requestOpcodes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "keyless_request_opcodes",
+			Help: "Number of requests received with various opcodes.",
+		}, []string{"opcode"}),
 	}
-	return stats
 }
 
 // logInvalid increments the error count and updates the error percentage.
-func (stats *statistics) logInvalid(requestBegin time.Time) {
+func (stats *statistics) logInvalid(opcode protocol.Op, requestBegin time.Time) {
 	stats.requestsInvalid.Inc()
-	stats.logRequestDuration(requestBegin)
+	stats.logRequestExecDuration(opcode, requestBegin)
 }
 
 // logConnFailure increments the error count of connFailures.
@@ -53,15 +73,26 @@ func (stats *statistics) logConnFailure() {
 	stats.connFailures.Inc()
 }
 
-// logRequest increments the request count and updates the error percentage.
-func (stats *statistics) logRequestDuration(requestBegin time.Time) {
-	stats.requestDuration.Observe(float64(time.Now().Sub(requestBegin)) / float64(time.Second))
+func (stats *statistics) logRequestExecDuration(opcode protocol.Op, requestBegin time.Time) {
+	stats.requestExecDuration.Observe(float64(time.Now().Sub(requestBegin)) / float64(time.Second))
+	stats.requestExecDurationByOpcode.WithLabelValues(opcode.String()).
+		Observe(float64(time.Now().Sub(requestBegin)) / float64(time.Second))
+}
+
+func (stats *statistics) logRequestTotalDuration(opcode protocol.Op, requestBegin time.Time) {
+	stats.requestTotalDuration.Observe(float64(time.Now().Sub(requestBegin)) / float64(time.Second))
+	stats.requestTotalDurationByOpcode.WithLabelValues(opcode.String()).
+		Observe(float64(time.Now().Sub(requestBegin)) / float64(time.Second))
 }
 
 func (stats *statistics) logEnqueueECDSARequest() { stats.queuedECDSARequests.Inc() }
 func (stats *statistics) logDeqeueECDSARequest()  { stats.queuedECDSARequests.Dec() }
 func (stats *statistics) logEnqueueOtherRequest() { stats.queuedOtherRequests.Inc() }
 func (stats *statistics) logDeqeueOtherRequest()  { stats.queuedOtherRequests.Dec() }
+
+func (stats *statistics) logRequestOpcode(opcode protocol.Op) {
+	stats.requestOpcodes.WithLabelValues(opcode.String()).Inc()
+}
 
 // MetricsListenAndServe serves Prometheus metrics at metricsAddr
 func (s *Server) MetricsListenAndServe(metricsAddr string) error {
@@ -78,10 +109,14 @@ func (s *Server) MetricsListenAndServe(metricsAddr string) error {
 // RegisterMetrics registers server metrics with global prometheus handler
 func (s *Server) RegisterMetrics() {
 	prometheus.MustRegister(
-		s.stats.requestDuration,
+		s.stats.requestExecDuration,
+		s.stats.requestTotalDuration,
+		s.stats.requestExecDurationByOpcode,
+		s.stats.requestTotalDurationByOpcode,
 		s.stats.requestsInvalid,
 		s.stats.connFailures,
 		s.stats.queuedECDSARequests,
 		s.stats.queuedOtherRequests,
+		s.stats.requestOpcodes,
 	)
 }


### PR DESCRIPTION
- We currently measure the time to execute a request once it is dequeued; add a metric to measure the total time to execute a request /including/ the time spent in queues.
- Add a metric to count which opcodes appear in requests.