### PR TITLE
server: Add RSA precomputation and multiprime benchmarks

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,10 @@ var keyExt = regexp.MustCompile(`.+\.key`)
 // Keystore is an abstract container for a server's private keys, allowing
 // lookup of keys based on incoming `Operation` requests.
 type Keystore interface {
+	// Get retreives a key for signing. The Sign method will be called directly on
+	// this key, so it's advisable to perform any precomputation on this key that
+	// may speed up signing over the course of multiple signatures (e.g.,
+	// crypto/rsa.PrivateKey's Precompute method).
 	Get(*protocol.Operation) (crypto.Signer, bool)
 }
 


### PR DESCRIPTION
Most of the time, RSA private keys should already include cached precomputed values. This PR adds a check that precomputes them in case they haven't been already. It's mostly a hedge against client code forgetting to precompute, which should be uncommon since most of the standard library precomputes under the hood when generating private keys (either from scratch or when parsing files).