### PR TITLE
cmd/gokeyless: Prompt for "Origin CA Key" instead of "Certificates API Key"

### DIFF
--- a/cmd/gokeyless/initialize.go
+++ b/cmd/gokeyless/initialize.go
@@ -103,7 +103,7 @@ func tokenFromPrompt() string {
 		fmt.Print("Cloudflare Zone ID for this Keyless server: ")
 		fmt.Scanln(&zoneID)
 	}
-	fmt.Print("Certificates API Key: ")
+	fmt.Print("Origin CA Key: ")
 	fmt.Scanln(&token)
 	return token
 }


### PR DESCRIPTION
Closes #207