### PR TITLE
Don't measure key load time as part of execution time metric

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -88,9 +88,8 @@ func newStatistics() *statistics {
 }
 
 // logInvalid increments the error count and updates the error percentage.
-func (stats *statistics) logInvalid(opcode protocol.Op, requestBegin time.Time) {
+func (stats *statistics) logInvalid(opcode protocol.Op) {
 	stats.requestsInvalid.Inc()
-	stats.logRequestExecDuration(opcode, 0, requestBegin)
 }
 
 // logConnFailure increments the error count of connFailures.


### PR DESCRIPTION
- For requests that involve loading a private key, don't include the time to load that key in the measured duration of the request execution.
- Make `logInvalid` not measure request execution duration.
- Don't log total request duration (`logRequestTotalDuration`) when there is an error in executing the request.

Closes #211