### PR TITLE
Revert "server: Modify metrics to log number of RSA primes in certain…

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,6 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"sync"
@@ -274,7 +273,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 	var ok bool
 	switch pkt.Operation.Opcode {
 	case protocol.OpPing:
-		w.s.stats.logRequestExecDuration(pkt.Opcode, 0, requestBegin)
+		w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 		return makePongResponse(req, pkt.Operation.Payload)
 
 	case protocol.OpSeal, protocol.OpUnseal:
@@ -300,7 +299,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 			w.s.stats.logInvalid(pkt.Opcode)
 			return makeErrResponse(req, code)
 		}
-		w.s.stats.logRequestExecDuration(pkt.Opcode, 0, requestBegin)
+		w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 		return makeRespondResponse(req, res)
 
 	case protocol.OpRPC:
@@ -313,7 +312,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 			return makeErrResponse(req, protocol.ErrInternal)
 		}
 
-		w.s.stats.logRequestExecDuration(pkt.Opcode, 0, requestBegin)
+		w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 		return makeRespondResponse(req, codec.response)
 
 	case protocol.OpRSADecrypt:
@@ -342,7 +341,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 				w.s.stats.logInvalid(pkt.Opcode)
 				return makeErrResponse(req, protocol.ErrCrypto)
 			}
-			w.s.stats.logRequestExecDuration(pkt.Opcode, len(rsaKey.Primes), requestBegin)
+			w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 			return makeRespondResponse(req, ptxt)
 		}
 
@@ -360,7 +359,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 			return makeErrResponse(req, protocol.ErrCrypto)
 		}
 
-		w.s.stats.logRequestExecDuration(pkt.Opcode, 0, requestBegin)
+		w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 		return makeRespondResponse(req, ptxt)
 	case protocol.OpRSASignMD5SHA1:
 		opts = crypto.MD5SHA1
@@ -413,14 +412,7 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 		return makeErrResponse(req, protocol.ErrCrypto)
 	}
 
-	primes := 0
-	if k, ok := key.(*rsa.PrivateKey); ok {
-		primes = len(k.Primes)
-	} else {
-		log.Warningf("Unexpected RSA private key type: got %v, expected *crypto/rsa.PrivateKey", reflect.TypeOf(key))
-	}
-
-	w.s.stats.logRequestExecDuration(pkt.Opcode, primes, requestBegin)
+	w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 	return makeRespondResponse(req, sig)
 }
 
@@ -503,7 +495,7 @@ func (w *ecdsaWorker) Do(job interface{}) interface{} {
 		return makeErrResponse(req, protocol.ErrCrypto)
 	}
 
-	w.s.stats.logRequestExecDuration(pkt.Opcode, 0, requestBegin)
+	w.s.stats.logRequestExecDuration(pkt.Opcode, requestBegin)
 	return makeRespondResponse(req, sig)
 }
 


### PR DESCRIPTION
… cases"

This reverts commit b07bc9ccdd084e65b6eb07ca28b82756f2f5879e.

I don't think we intend to exercise this information, and it creates a DoS vector (possibly large number of labels).