### PR TITLE
server: Fix measurements of the number of primes in an RSA key

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -112,6 +112,12 @@ func (stats *statistics) logRequestExecDuration(opcode protocol.Op, primes int, 
 		protocol.OpRSASignSHA224, protocol.OpRSASignSHA256, protocol.OpRSASignSHA384,
 		protocol.OpRSASignSHA512, protocol.OpRSAPSSSignSHA256,
 		protocol.OpRSAPSSSignSHA384, protocol.OpRSAPSSSignSHA512:
+		if primes > 10 {
+			// if a key has more than 10 primes, it is:
+			// a) degenerate, and so we don't care about measuring its performance
+			// b) probably a DoS attack to try to get us to generate tons of labels
+			primes = 0
+		}
 		primesStr = fmt.Sprint(primes)
 	}
 	stats.requestExecDurationByOpcode.WithLabelValues(opcode.String(), primesStr).

--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,6 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"sync"
@@ -416,8 +415,6 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 	primes := 0
 	if k, ok := key.(*rsa.PrivateKey); ok {
 		primes = len(k.Primes)
-	} else {
-		log.Warningf("Unexpected RSA private key type: got %v, expected *crypto/rsa.PrivateKey", reflect.TypeOf(key))
 	}
 
 	w.s.stats.logRequestExecDuration(pkt.Opcode, primes, requestBegin)


### PR DESCRIPTION
- Don't warn about RSA keys that are not `*rsa.PrivateKey`.
- Impose a limit of 10 primes in order to avoid a DoS vector.