### PR TITLE
Don't ask for user input by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+gokeyless

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,8 @@ $(RPM_PACKAGE): | $(INSTALL_BIN)/$(NAME) install-config
 	--rpm-use-file-permissions \
 	--rpm-user root --rpm-group root \
 	.
+
+.PHONY: dev
+dev: gokeyless
+gokeyless: $(shell find . -type f -name '*.go')
+	go build -ldflags "-X main.version=dev" -o $@ ./cmd/gokeyless/...

--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -95,8 +95,13 @@ func main() {
 		os.Exit(0)
 	}
 
+	// If we make it here we need to ask for user input, so we need to give up
+	// and log an error instead (in case the server is running as a daemon).
+	// Failing hard with an error message makes the problem obvious, whereas a
+	// daemon blocked waiting on input can be hard to debug.
 	if needNewCertAndKey() {
-		initializeServerCertAndKey()
+		log.Error("the server cert/key need to be generated; run the server with either the -config-only or -manual-activation flag to generate the pair")
+		os.Exit(1)
 	}
 
 	s, err := server.NewServerFromFile(certFile, keyFile, caFile)


### PR DESCRIPTION
The default behavior of the keyless server when the `server.pem` and `server-key.pem` files are not present is to ask the user for input to generate them. But if the server was launched as a daemon, it will just be stuck waiting for input, while appearing to be running.

With this change, the user will not be prompted for input unless the `-config-only` or `-manual-activation` flags are provided.