### PR TITLE
Allow the blacklisting of entire subnets.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"net"
+	"testing"
+)
+
+func TestAddrSet(t *testing.T) {
+	as := &AddrSet{}
+
+	as.Add(&net.IPAddr{IP: net.IPv4(0, 0, 0, 0)}, 2407)
+	as.Add(&net.IPAddr{IP: net.IPv4(1, 1, 1, 1)}, 2407)
+	as.Add(&net.IPNet{IP: net.IPv4(127, 0, 0, 1), Mask: net.CIDRMask(8, 32)}, 2407)
+
+	if !as.Contains(&net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 2407}) {
+		t.Fatal("doesn't contain address that was added explicitly")
+	}
+
+	if as.Contains(&net.TCPAddr{IP: net.IPv4(2, 2, 2, 2), Port: 2407}) {
+		t.Fatal("contains address that wasn't added")
+	} else if as.Contains(&net.TCPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 2406}) {
+		t.Fatal("contains address with port that wasn't added")
+	} else if !as.Contains(&net.TCPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 2407}) {
+		t.Fatal("doesn't contain address that was added explicitly")
+	}
+
+	if as.Contains(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2406}) {
+		t.Fatal("contains address with port that wasn't added")
+	} else if !as.Contains(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2407}) {
+		t.Fatal("doesn't contain address in subnet")
+	} else if !as.Contains(&net.TCPAddr{IP: net.IPv4(127, 2, 3, 4), Port: 2407}) {
+		t.Fatal("doesn't contain address in subnet")
+	}
+}

--- a/client/remote.go
+++ b/client/remote.go
@@ -240,7 +240,7 @@ func (c *Client) LookupServer(hostport string) (Remote, error) {
 
 // Dial dials a remote server, returning an existing connection if possible.
 func (s *singleRemote) Dial(c *Client) (*Conn, error) {
-	if c.Blacklist.Contains(s) {
+	if c.Blacklist.Contains(s.Addr) {
 		return nil, fmt.Errorf("server %s on client blacklist", s.String())
 	}
 


### PR DESCRIPTION
This is for the case where a keyless server listens on an entire subnet (the easy example being 127.0.0.1/8) and we want to blacklist ourselves from connecting to anything in there, creating a routing loop.