### PR TITLE
Share a common pool of workers across listeners

### DIFF
--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -56,7 +56,7 @@ func LoadKey(in []byte) (priv crypto.Signer, err error) {
 func TestMain(m *testing.M) {
 	var err error
 	// Setup keyless server
-	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA)
+	s, err = server.NewServerFromFile(nil, serverCert, serverKey, keylessCA)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -173,7 +173,8 @@ func TestBadRemote(t *testing.T) {
 
 func TestSlowServer(t *testing.T) {
 	// Setup a slow keyless server
-	s2, err := server.NewServerFromFile(serverCert, serverKey, keylessCA)
+	cfg := server.DefaultServeConfig().TCPTimeout(time.Second * 30)
+	s2, err := server.NewServerFromFile(cfg, serverCert, serverKey, keylessCA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,9 +186,7 @@ func TestSlowServer(t *testing.T) {
 	sl := slowListener{l}
 
 	go func() {
-		cfg := server.DefaultServeConfig()
-		cfg.TCPTimeout(time.Second * 30)
-		if err := s2.ServeConfig(&sl, cfg); err != nil {
+		if err := s2.Serve(&sl); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -104,7 +104,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	s, err := server.NewServerFromFile(certFile, keyFile, caFile)
+	cfg := server.DefaultServeConfig()
+	s, err := server.NewServerFromFile(cfg, certFile, keyFile, caFile)
 	if err != nil {
 		log.Fatal("cannot start server:", err)
 	}
@@ -125,9 +126,8 @@ func main() {
 		}
 	}
 
-	cfg := server.DefaultServeConfig().TCPAddr(net.JoinHostPort("", port))
 	go func() { log.Critical(s.MetricsListenAndServe(metricsAddr)) }()
-	log.Fatal(s.ListenAndServeConfig(cfg))
+	log.Fatal(s.ListenAndServe(net.JoinHostPort("", port)))
 }
 
 // LoadKey attempts to load a private key from PEM or DER.

--- a/server/server.go
+++ b/server/server.go
@@ -127,7 +127,7 @@ func (keys *DefaultKeystore) Get(op *protocol.Operation) (crypto.Signer, bool) {
 // Server is a Keyless Server capable of performing opaque key operations.
 type Server struct {
 	config *ServeConfig
-	// config is initialized with the auth configuration used for communicating with keyless clients.
+	// tlsConfig is initialized with the auth configuration used for communicating with keyless clients.
 	tlsConfig *tls.Config
 	// keys contains the private keys and certificates for the server.
 	keys Keystore

--- a/server/worker_pool.go
+++ b/server/worker_pool.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"sync"
+	"time"
+
+	buf_ecdsa "github.com/cloudflare/gokeyless/server/internal/ecdsa"
+	"github.com/cloudflare/gokeyless/server/internal/worker"
+)
+
+type workerPool struct {
+	ECDSA *worker.Pool
+	Other *worker.Pool
+
+	bg     *worker.BackgroundPool
+	utilCh chan struct{}
+	utilWg sync.WaitGroup
+}
+
+func newWorkerPool(s *Server) *workerPool {
+	var others []worker.Worker
+	var ecdsas []worker.Worker
+	var background []worker.BackgroundWorker
+	rbuf := buf_ecdsa.NewSyncRandBuffer(randBufferLen, elliptic.P256())
+	for i := 0; i < s.config.otherWorkers; i++ {
+		others = append(others, newOtherWorker(s, fmt.Sprintf("other-%v", i)))
+	}
+	for i := 0; i < s.config.ecdsaWorkers; i++ {
+		ecdsas = append(ecdsas, newECDSAWorker(s, rbuf, fmt.Sprintf("ecdsa-%v", i)))
+	}
+	for i := 0; i < s.config.bgWorkers; i++ {
+		background = append(background, newRandGenWorker(rbuf))
+	}
+
+	wp := &workerPool{
+		ECDSA:  worker.NewPool(ecdsas...),
+		Other:  worker.NewPool(others...),
+		bg:     worker.NewBackgroundPool(background...),
+		utilCh: make(chan struct{}),
+	}
+
+	if util := s.config.utilization; util != nil {
+		go func() {
+			ticker := time.NewTicker(1 * time.Second)
+			wp.utilWg.Add(1)
+			for {
+				select {
+				case <-ticker.C:
+					util(
+						float64(wp.Other.Busy())/float64(s.config.otherWorkers),
+						float64(wp.ECDSA.Busy())/float64(s.config.ecdsaWorkers),
+					)
+
+				case <-wp.utilCh:
+					ticker.Stop()
+					wp.utilWg.Done()
+					return
+				}
+			}
+		}()
+	}
+
+	return wp
+}
+
+func (wp *workerPool) Destroy() {
+	// Destroy the pools
+	wp.bg.Destroy()
+	wp.Other.Destroy()
+	wp.ECDSA.Destroy()
+	// Stop publishing utilization info.
+	close(wp.utilCh)
+	wp.utilWg.Wait()
+}

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -106,7 +106,7 @@ func init() {
 
 	log.Level = log.LevelFatal
 
-	s, err = server.NewServerFromFile(serverCert, serverKey, keylessCA)
+	s, err = server.NewServerFromFile(nil, serverCert, serverKey, keylessCA)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -125,8 +125,7 @@ func init() {
 	listening := make(chan bool)
 	go func() {
 		listening <- true
-		cfg := server.DefaultServeConfig().TCPAddr(serverAddr)
-		if err := s.ListenAndServeConfig(cfg); err != nil {
+		if err := s.ListenAndServe(serverAddr); err != nil {
 			log.Fatal(err)
 		}
 	}()


### PR DESCRIPTION
The pool will be created when the first listener is started, and will be
torn down after the last listener is closed.

And since we are going to share a pool of workers, we also needed to
refactor `Server` to share a config across listeners. Users who wish to
vary the config across listeners will need to configure multiple `Server`
instances.