### PR TITLE
Don't attempt to include pkcs#11 support if cgo is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build/
-gokeyless
+/gokeyless

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ SYSTEMD_PREFIX               := $(DESTDIR)/lib/systemd/system
 CONFIG_PATH                  := etc/keyless
 CONFIG_PREFIX                := $(DESTDIR)/$(CONFIG_PATH)
 
-ARCH := amd64
+OS ?= linux
+ARCH ?= amd64
 DEB_PACKAGE := $(NAME)_$(VERSION)_$(ARCH).deb
 RPM_PACKAGE := $(NAME)-$(VERSION).$(ARCH).rpm
 
@@ -34,7 +35,7 @@ install-config:
 	@install -m600 pkg/gokeyless.yaml $(CONFIG_PREFIX)/gokeyless.yaml
 
 $(INSTALL_BIN)/$(NAME): | install-config
-	@GOOS=linux GOARCH=$(ARCH) go build -ldflags $(LDFLAGS) -o $@ ./cmd/$(NAME)/...
+	@GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags $(LDFLAGS) -o $@ ./cmd/$(NAME)/...
 
 .PHONY: clean
 clean:

--- a/cmd/gokeyless/.gitignore
+++ b/cmd/gokeyless/.gitignore
@@ -1,0 +1,2 @@
+/gokeyless
+/gokeyless.yaml

--- a/cmd/gokeyless/cgo.go
+++ b/cmd/gokeyless/cgo.go
@@ -1,0 +1,13 @@
+// +build cgo
+
+package main
+
+import (
+	"crypto"
+
+	"github.com/cloudflare/gokeyless/server"
+)
+
+func loadURI(uri string) (crypto.Signer, error) {
+	return server.DefaultLoadURI(uri)
+}

--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -275,7 +275,7 @@ func initKeyStore() (server.Keystore, error) {
 				return nil, err
 			}
 		case store.URI != "":
-			if err := keys.AddFromURI(store.URI, server.DefaultLoadURI); err != nil {
+			if err := keys.AddFromURI(store.URI, loadURI); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/gokeyless/nocgo.go
+++ b/cmd/gokeyless/nocgo.go
@@ -1,0 +1,12 @@
+// +build !cgo
+
+package main
+
+import (
+	"crypto"
+	"fmt"
+)
+
+func loadURI(uri string) (crypto.Signer, error) {
+	return nil, fmt.Errorf("this binary was built with cgo disabled, therefore pkcs#11 is not supported")
+}

--- a/internal/rfc7512/rfc7512.go
+++ b/internal/rfc7512/rfc7512.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 // Package rfc7512 provides a parser for the PKCS #11 URI format as specified in
 // RFC 7512: The PKCS #11 URI Scheme. Additionally, it provides a wrapper around
 // the crypto11 package for loading a key pair as a crypto.Signer object.

--- a/server/pkcs11.go
+++ b/server/pkcs11.go
@@ -1,0 +1,22 @@
+// +build cgo
+
+package server
+
+import (
+	"crypto"
+
+	"github.com/cloudflare/gokeyless/internal/rfc7512"
+)
+
+// DefaultLoadURI attempts to load a signer from a PKCS#11 URI.
+func DefaultLoadURI(uri string) (crypto.Signer, error) {
+	// This wrapper is here in case we want to parse vendor specific values
+	// based on the parameters in the URI or perform side operations, such
+	// as waiting for network to be up.
+	pk11uri, err := rfc7512.ParsePKCS11URI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	return rfc7512.LoadPKCS11Signer(pk11uri)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/helpers/derhelpers"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/gokeyless/internal/rfc7512"
 	"github.com/cloudflare/gokeyless/protocol"
 	"github.com/cloudflare/gokeyless/server/internal/client"
 	buf_ecdsa "github.com/cloudflare/gokeyless/server/internal/ecdsa"
@@ -144,19 +143,6 @@ func DefaultLoadKey(in []byte) (priv crypto.Signer, err error) {
 	}
 
 	return derhelpers.ParsePrivateKeyDER(in)
-}
-
-// DefaultLoadURI attempts to load a signer from a PKCS#11 URI.
-func DefaultLoadURI(uri string) (crypto.Signer, error) {
-	// This wrapper is here in case we want to parse vendor specific values
-	// based on the parameters in the URI or perform side operations, such
-	// as waiting for network to be up.
-	pk11uri, err := rfc7512.ParsePKCS11URI(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	return rfc7512.LoadPKCS11Signer(pk11uri)
 }
 
 // Get returns a key from keys, mapped from SKI.


### PR DESCRIPTION
It is disabled by default when cross compiling.