### PR TITLE
Configuration fixes

### DIFF
--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -122,6 +122,7 @@ func initConfig() error {
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
 	viper.AutomaticEnv()
+	viper.SetEnvPrefix("KEYLESS")
 
 	viper.SetConfigType("yaml")
 	if configFile != "" {

--- a/pkg/gokeyless.sysv
+++ b/pkg/gokeyless.sysv
@@ -35,7 +35,7 @@ WORKDIR=/etc/keyless
 USER=keyless
 GROUP=keyless
 
-args="-pid-file=${pidfile}"
+args="--pid-file=${pidfile}"
 
 trace() {
   logger -t "/etc/init.d/gokeyless" "$@"

--- a/pkg/gokeyless.yaml
+++ b/pkg/gokeyless.yaml
@@ -27,5 +27,6 @@ cloudflare_ca_cert: /etc/keyless/keyless_cacert.pem
 port: 2407
 metrics_port: 2406
 
-# Optionally write the PID to a file.
+# Optionally write the PID to a file (note that sysv-based systems will
+# ignore this value and always use /var/run/gokeyless.pid).
 pid_file:


### PR DESCRIPTION
- Fix `--pid-file` argument for sysv-based systems
- Require `KEYLESS_` prefix for environment variables to avoid accidental conflicts with generically named parameters like hostname