### PR TITLE
Remove keys from DefaultKeystore

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,16 @@ func (keys *DefaultKeystore) Add(op *protocol.Operation, priv crypto.Signer) err
 	return nil
 }
 
+// Remove removes a key from the server's internal state.
+func (keys *DefaultKeystore) Remove(ski protocol.SKI) {
+	keys.mtx.Lock()
+	defer keys.mtx.Unlock()
+
+	delete(keys.skis, ski)
+
+	log.Debugf("remove signer with SKI: %v", ski)
+}
+
 // DefaultLoadKey attempts to load a private key from PEM or DER.
 func DefaultLoadKey(in []byte) (priv crypto.Signer, err error) {
 	priv, err = helpers.ParsePrivateKeyPEM(in)

--- a/tests/keystore_test.go
+++ b/tests/keystore_test.go
@@ -1,0 +1,37 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/cloudflare/gokeyless/protocol"
+	"github.com/cloudflare/gokeyless/server"
+)
+
+func TestDefaultKeyStoreAddRemove(t *testing.T) {
+	ski, err := protocol.GetSKI(ed25519Key.Public())
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := &protocol.Operation{SKI: ski}
+
+	keys := server.NewDefaultKeystore()
+	err = keys.AddFromFile(ed25519PrivKey, server.DefaultLoadKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := keys.Get(op)
+	if err != nil {
+		t.Fatal(err)
+	} else if priv == nil {
+		t.Fatalf("no key with SKI %s, expected a key", ski)
+	}
+
+	keys.Remove(ski)
+	priv, err = keys.Get(op)
+	if err != nil {
+		t.Fatal(err)
+	} else if priv != nil {
+		t.Fatalf("got key with SKI %s, expected no key", ski)
+	}
+}


### PR DESCRIPTION
Based on #242 

This adds a function for remove keys from the DefaultKeystore. Keys associated with delegated credentials are short-lived, so a server with a long uptime will need to be able to prune its memory. It's the caller's responsibility to keep track of when keys expired and need to be pruned.