### PR TITLE
Speed up RPC-over-Keyless

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -29,6 +29,10 @@ type conn struct {
 	closed uint32 // set to 1 when the conn is closed.
 
 	stats *connStats
+
+	// An RPC server codec is created for each connection. This is passed by
+	// reference to the worker handling a job.
+	codec *serverCodec
 }
 
 type connEvent struct {
@@ -75,6 +79,7 @@ func newConn(s *Server, name string, c net.Conn, timeout time.Duration, ecdsa, o
 		stats: &connStats{
 			spawnTime: time.Now(),
 		},
+		codec: newServerCodec(),
 	}
 }
 
@@ -117,6 +122,7 @@ func (c *conn) GetJob() (job interface{}, pool *worker.Pool, ok bool) {
 		pkt:      pkt,
 		reqBegin: time.Now(),
 		connName: c.name,
+		codec:    c.codec,
 	}
 
 	c.stats.lock.Lock()

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -334,14 +334,20 @@ func TestKeylessDummyRPC(t *testing.T) {
 		t.Fatal("recieved wrong output")
 	}
 
+	if err = client.Call("DummyRPC.Append", "What A Wonderful", &out); err != nil {
+		t.Fatal(err)
+	} else if out != "What A Wonderful World" {
+		t.Fatal("recieved wrong output")
+	}
+
 	err = client.Call("DummyRPC.Error", "Hello", &out)
 	if err == nil || err.Error() != "remote rpc error" {
-		t.Fatal("recieved wrong error")
+		t.Fatal("recieved wrong error", err)
 	}
 }
 
 func benchmarkDummyRPC(b *testing.B, requester *rpc.Client) {
-	resp := "{"
+	resp := ""
 	if err := requester.Call("DummyRPC.Append", "Hello", &resp); err != nil {
 		b.Fatal(err)
 	}
@@ -398,12 +404,10 @@ func BenchmarkDummyRPC(b *testing.B) {
 	defer l.Close()
 
 	// Listen for and serve a single connection.
-	var serr error
 	sch := make(chan net.Conn, 1)
 	go func() {
 		sconn, err := l.Accept()
 		if err != nil {
-			serr = err
 			sch <- nil
 			return
 		}


### PR DESCRIPTION
This adds benchmarks for comparing standard RPC to RPC-over-Keyless. If you checkout https://github.com/cloudflare/gokeyless/commit/255c0f3eb63bc54b7fb6b48798c3aed6da1bbf80 and run `cd tests && go test -bench .`, you'll see that RPC-over-Keyless is up to 10x as slow as RPC:
```
pkg: github.com/cloudflare/gokeyless/tests
BenchmarkKeylessDummyRPC-4   	   10000	    169289 ns/op	   32688 B/op	     471 allocs/op
BenchmarkDummyRPC-4          	  100000	     16991 ns/op	     400 B/op	      12 allocs/op
```
Commit https://github.com/cloudflare/gokeyless/pull/245/commits/6efd7c35b7207a435a7bb2eac6c001ce7a7f999c makes RPC-over-Keyless faster by making encoding and decoding of RPCs stateful. This improves performance by up to a factor of 2:
```
pkg: github.com/cloudflare/gokeyless/tests
BenchmarkKeylessDummyRPC-4   	   20000	     81775 ns/op	   10935 B/op	      48 allocs/op
BenchmarkDummyRPC-4          	  100000	     16408 ns/op	     388 B/op	      12 allocs/op
```
I think there's definitely room for improvement, but it would take some work. This PR is meant to be minimally invasive.

NOTE: this PR changes the wire protocol. If an out-of-date client tries to use RPC with a current server (or vice versa), then the call will fail.