### PR TITLE
Fixes to make tests independent of the current time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
   - go install ./vendor/golang.org/x/tools/cmd/goimports
   - go install ./vendor/golang.org/x/lint/golint
 
+go_import_path: github.com/cloudflare/gokeyless
+
 script:
   - make vet lint test-nohsm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - go: 1.9.x
     - go: 1.10.x
     - go: 1.11.x
+    - go: 1.12.x
   allow_failures:
     - go: master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 go_import_path: github.com/cloudflare/gokeyless
 
 script:
-  - make vet lint test-nohsm
+  - make vet lint test-nohsm test-trust
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,10 @@ test:
 test-nohsm:
 	GODEBUG=cgocheck=2 go test -v -cover -race `go list ./... | grep -v /vendor/`
 
+.PHONY: test-trust
+test-trust: gokeyless
+	tests/trust-check.sh
+
 .PHONY: benchmark-softhsm
 benchmark-softhsm:
 	go test -v -race ./server -bench HSM -args -softhsm2

--- a/client/remote.go
+++ b/client/remote.go
@@ -249,7 +249,7 @@ func (s *singleRemote) Dial(c *Client) (*Conn, error) {
 		return cn, nil
 	}
 
-	config := copyTLSConfig(c.Config)
+	config := c.Config.Clone()
 	config.ServerName = s.ServerName
 	log.Debugf("Dialing %s at %s\n", s.ServerName, s.String())
 	inner, err := tls.DialWithDialer(c.Dialer, s.Network(), s.String(), config)
@@ -288,28 +288,6 @@ func (s *singleRemote) PingAll(c *Client, concurrency int) {
 	err = cn.Conn.Ping(nil)
 	if err != nil {
 		cn.Close()
-	}
-}
-
-func copyTLSConfig(c *tls.Config) *tls.Config {
-	return &tls.Config{
-		Certificates:             c.Certificates,
-		NameToCertificate:        c.NameToCertificate,
-		GetCertificate:           c.GetCertificate,
-		RootCAs:                  c.RootCAs,
-		NextProtos:               c.NextProtos,
-		ServerName:               c.ServerName,
-		ClientAuth:               c.ClientAuth,
-		ClientCAs:                c.ClientCAs,
-		InsecureSkipVerify:       c.InsecureSkipVerify,
-		CipherSuites:             c.CipherSuites,
-		PreferServerCipherSuites: c.PreferServerCipherSuites,
-		SessionTicketsDisabled:   c.SessionTicketsDisabled,
-		SessionTicketKey:         c.SessionTicketKey,
-		ClientSessionCache:       c.ClientSessionCache,
-		MinVersion:               c.MinVersion,
-		MaxVersion:               c.MaxVersion,
-		CurvePreferences:         c.CurvePreferences,
 	}
 }
 

--- a/client/remote_test.go
+++ b/client/remote_test.go
@@ -42,6 +42,11 @@ var (
 	deadRemote  Remote
 )
 
+func fixedCurrentTime() time.Time {
+	// Fixed time where certificates are still valid.
+	return time.Date(2019, time.March, 1, 0, 0, 0, 0, time.UTC)
+}
+
 // LoadKey attempts to load a private key from PEM or DER.
 func LoadKey(in []byte) (priv crypto.Signer, err error) {
 	priv, err = helpers.ParsePrivateKeyPEM(in)
@@ -60,6 +65,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	s.TLSConfig().Time = fixedCurrentTime
 
 	keys, err := server.NewKeystoreFromDir("testdata", LoadKey)
 	if err != nil {
@@ -88,6 +94,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	c.Config.Time = fixedCurrentTime
 	// set aggressive timeout since all tests use local connections
 	c.Dialer.Timeout = 3 * time.Second
 
@@ -178,6 +185,7 @@ func TestSlowServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	s2.TLSConfig().Time = fixedCurrentTime
 
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -43,6 +43,11 @@ var (
 	remote     client.Remote
 )
 
+func fixedCurrentTime() time.Time {
+	// Fixed time where certificates are still valid.
+	return time.Date(2019, time.March, 1, 0, 0, 0, 0, time.UTC)
+}
+
 var testSoftHSM bool
 
 type dummySealer struct{}
@@ -112,6 +117,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	s.TLSConfig().Time = fixedCurrentTime
 
 	if !testSoftHSM {
 		keys, err := server.NewKeystoreFromDir("testdata", server.DefaultLoadKey)
@@ -148,6 +154,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	c.Config.Time = fixedCurrentTime
 
 	remote, err = c.LookupServer(serverAddr)
 	if err != nil {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -97,6 +97,7 @@ func TestTLSProxy(t *testing.T) {
 	}
 
 	clientConfig := &tls.Config{
+		Time:       fixedCurrentTime,
 		ServerName: serverConfig.Certificates[0].Leaf.Subject.CommonName,
 		RootCAs:    x509.NewCertPool(),
 	}

--- a/tests/trust-check.sh
+++ b/tests/trust-check.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Verify that mutual certificate authentication with the Keyless server has
+# proper certificate validation.
+set -e
+
+wait_for_port_pid() {
+    local port=$1 pid=$2 timeout=10
+
+    for ((i=0; i<10*timeout; i++)); do
+        if nc -z localhost $port; then
+            return
+        fi
+        # Stop checking if the process has died.
+        kill -0 $pid 2>/dev/null || return 2
+        sleep .1
+    done
+
+    echo "Port $port not responding after $timeout seconds!"
+    return 1
+}
+
+date_to_unix() {
+    case "$(uname -s)" in
+    Darwin)
+        date -j -f %Y-%m-%dT%H:%M:%SZ "$1" +%s
+        ;;
+    *)
+        date -d "$1" +%s
+        ;;
+    esac
+}
+
+keyless_connect() {
+    local current_time="$1" current_time_unix="$(date_to_unix "$1")"
+
+    ./gokeyless \
+        --auth_cert tests/testdata/server.pem \
+        --auth_key tests/testdata/server-key.pem \
+        --cloudflare_ca_cert tests/testdata/ca.pem \
+        --current-time "$current_time" & keyless_pid=$!
+
+    if ! wait_for_port_pid 2407 $keyless_pid; then
+        kill $keyless_pid || :
+        return 1
+    fi
+
+    # For less spam, add -brief, but that requires OpenSSL >= 1.1.0
+    echo | openssl s_client \
+        -connect localhost:2407 \
+        -cert tests/testdata/client.pem \
+        -key tests/testdata/client-key.pem \
+        -CAfile tests/testdata/ca.pem \
+        -verify 2 -verify_return_error \
+        -attime $current_time_unix; rc=$?
+
+    kill $keyless_pid || :
+    return $rc
+}
+
+fail() {
+    echo "FAIL: $1"
+    exit 1
+}
+
+echo "Checking validation of a valid certificate"
+keyless_connect 2019-01-01T00:00:00Z ||
+    fail "Should pass on a valid certificate"
+
+echo "Checking validation of an expired certificate"
+keyless_connect 2119-01-01T00:00:00Z &&
+    fail "Should fail connection on expired certificate"
+
+echo PASSED


### PR DESCRIPTION
Certificate validation is dependent on the current time, to ensure that tests won't fail in 98 years, make sure that the reference time is fixed.

I've also updated the Travis config while at it, let me know if you prefer a separate PR for that.

The change has additionally been [verified](https://travis-ci.org/Lekensteyn/gokeyless/jobs/509410011) by changing the system time with:
```diff
--- a/tests/trust-check.sh
+++ b/tests/trust-check.sh
@@ -62,6 +62,13 @@ fail() {
     exit 1
 }
 
+# Ensure that tests are run far in the future to ensure that time overrides work
+# as intended.
+if [[ "$(uname -s)" == Linux ]]; then
+    sudo date -s '+200 year'
+    trap "sudo date -s '-200 year'" EXIT
+fi
+
 echo "Checking validation of a valid certificate"
 keyless_connect 2019-01-01T00:00:00Z ||
     fail "Should pass on a valid certificate"
```