### PR TITLE
Add Custom Function OpCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following tag values are possible for items:
     0x03 - Client's IP address,
     0x11 - Opcode,
     0x12 - Payload,
+    0x13 - CustomFuncName, (for use with opcode 0x24)
 
 A requests contains a header and the following items:
 
@@ -84,6 +85,7 @@ The following opcodes are supported in the opcode item:
     0x15 - operation: ECDSA sign SHA256
     0x16 - operation: ECDSA sign SHA384
     0x17 - operation: ECDSA sign SHA512
+    0x23 - operation: RPC
     0x24 - operation: Custom Function
     0x35 - operation: RSASSA-PSS sign SHA256
     0x36 - operation: RSASSA-PSS sign SHA384

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The following opcodes are supported in the opcode item:
     0x15 - operation: ECDSA sign SHA256
     0x16 - operation: ECDSA sign SHA384
     0x17 - operation: ECDSA sign SHA512
+    0x24 - operation: Custom Function
     0x35 - operation: RSASSA-PSS sign SHA256
     0x36 - operation: RSASSA-PSS sign SHA384
     0x36 - operation: RSASSA-PSS sign SHA512
@@ -135,7 +136,7 @@ The private keys that this server is able to use must be stored with a `.key` ex
 
     --private-key-dirs
 
-Note that the configuration file is the recommened way to specify these options; see below for more information.
+Note that the configuration file is the recommended way to specify these options; see below for more information.
 
 ### Hardware Security Modules
 
@@ -175,7 +176,7 @@ The the keyserver for Keyless SSL consists of a single binary file, `gokeyless`.
 
 You should add your Cloudflare account details to the configuration file, and optionally customize the location of the private key directory. Most users should not need to modify the remaining defaults.
 
-Each option can optionally be overriden via environment variables or command-line arguments. Run `gokeyless -h` to see the full list of available options.
+Each option can optionally be overridden via environment variables or command-line arguments. Run `gokeyless -h` to see the full list of available options.
 
 ## Testing
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -95,6 +95,8 @@ const (
 	OpUnseal Op = 0x22
 	// OpRPC executes an arbitrary exported function on the server.
 	OpRPC Op = 0x23
+	// OpCustom requests a custom operation that can be defined by a function set in the server configuration
+	OpCustom Op = 0x24
 
 	// OpPing indicates a test message which will be echoed with opcode changed to OpPong.
 	OpPing Op = 0xF1
@@ -114,6 +116,8 @@ func (op Op) Type() string {
 		return "rsa"
 	case OpECDSASignMD5SHA1, OpECDSASignSHA1, OpECDSASignSHA224, OpECDSASignSHA256, OpECDSASignSHA384, OpECDSASignSHA512:
 		return "ecdsa"
+	case OpCustom:
+		return "custom"
 	case OpRPC:
 		return "rpc"
 	case OpSeal, OpUnseal, OpPing, OpPong, OpResponse, OpError:
@@ -151,6 +155,8 @@ const (
 	ErrCertNotFound
 	// ErrExpired indicates that the sealed blob is no longer unsealable.
 	ErrExpired
+	// ErrCustomOpUndefined indicates that the custom opcode was invoked but no definition was provided to the server configuration.
+	ErrCustomOpCodeUndefined
 )
 
 func (e Error) Error() string {
@@ -181,6 +187,8 @@ func (e Error) String() string {
 		return "certificate not found"
 	case ErrExpired:
 		return "sealing key expired"
+	case ErrCustomOpCodeUndefined:
+		return "custom opcode function undefined"
 	default:
 		return "unknown error"
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -395,14 +395,14 @@ func (p *Packet) ReadFrom(r io.Reader) (n int64, err error) {
 
 // Operation defines a single (repeatable) keyless operation.
 type Operation struct {
-	Opcode   Op
-	Payload  []byte
-	SKI      SKI
-	Digest   Digest
-	ClientIP net.IP
-	ServerIP net.IP
-	SNI      string
-	CertID   string
+	Opcode         Op
+	Payload        []byte
+	SKI            SKI
+	Digest         Digest
+	ClientIP       net.IP
+	ServerIP       net.IP
+	SNI            string
+	CertID         string
 	CustomFuncName string
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -379,10 +379,10 @@ func (w *otherWorker) Do(job interface{}) interface{} {
 		customOpFunc := w.s.config.CustomOpFunc()
 		if customOpFunc == nil {
 			log.Errorf("Worker %v: OpCustom is undefined", w.name)
-			return w.s.makeErrResponse(req, protocol.ErrCustomOpCodeUndefined, requestBegin)
+			return w.s.makeErrResponse(req, protocol.ErrBadOpcode, requestBegin)
 		}
 
-		res, err := customOpFunc(pkt.Payload)
+		res, err := customOpFunc(pkt.Operation)
 		if err != nil {
 			log.Errorf("Worker %v: OpCustom failed: %v", w.name, err)
 			return w.s.makeErrResponse(req, protocol.ErrInternal, requestBegin)
@@ -832,7 +832,7 @@ type ServeConfig struct {
 	tcpTimeout, unixTimeout    time.Duration
 	utilization                func(other, ecdsa float64)
 	isLimited                  func(state tls.ConnectionState) (bool, error)
-	customOpFunc               func([]byte) ([]byte, error)
+	customOpFunc               func(protocol.Operation) ([]byte, error)
 }
 
 const (
@@ -956,13 +956,13 @@ func (s *ServeConfig) WithIsLimited(f func(state tls.ConnectionState) (bool, err
 }
 
 // WithCustomOpFunction defines a function to use with the OpCustom opcode.
-func (s *ServeConfig) WithCustomOpFunction(f func([]byte) ([]byte, error)) *ServeConfig {
+func (s *ServeConfig) WithCustomOpFunction(f func(protocol.Operation) ([]byte, error)) *ServeConfig {
 	s.customOpFunc = f
 	return s
 }
 
 // CustomOpFunc returns the CustomOpFunc
-func (s *ServeConfig) CustomOpFunc() func([]byte) ([]byte, error) {
+func (s *ServeConfig) CustomOpFunc() func(protocol.Operation) ([]byte, error) {
 	return s.customOpFunc
 }
 

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -233,11 +233,11 @@ func (s *IntegrationTestSuite) TestUndefinedCustomOp() {
 	defer conn.Close()
 
 	resp, err := conn.DoOperation(protocol.Operation{
-		Opcode:  protocol.OpCustom,
+		Opcode:         protocol.OpCustom,
 		CustomFuncName: "undefined",
 	})
 	require.NoError(err)
-	require.NotEqual(protocol.ErrBadOpcode, resp.Opcode, resp.GetError())
+	require.Equal(protocol.OpError, resp.Opcode, resp.GetError())
 }
 
 func (s *IntegrationTestSuite) TestConcurrency() {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -234,9 +234,10 @@ func (s *IntegrationTestSuite) TestUndefinedCustomOp() {
 
 	resp, err := conn.DoOperation(protocol.Operation{
 		Opcode:  protocol.OpCustom,
+		CustomFuncName: "undefined",
 	})
 	require.NoError(err)
-	require.NotEqual(protocol.ErrCustomOpCodeUndefined, resp.Opcode, resp.GetError())
+	require.NotEqual(protocol.ErrBadOpcode, resp.Opcode, resp.GetError())
 }
 
 func (s *IntegrationTestSuite) TestConcurrency() {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -225,6 +225,20 @@ func (s *IntegrationTestSuite) TestSeal() {
 	require.True(bytes.Equal(r, resp.Payload[len("OpUnseal "):]), "payload value mismatch")
 }
 
+func (s *IntegrationTestSuite) TestUndefinedCustomOp() {
+	require := require.New(s.T())
+
+	conn, err := s.remote.Dial(s.client)
+	require.NoError(err)
+	defer conn.Close()
+
+	resp, err := conn.DoOperation(protocol.Operation{
+		Opcode:  protocol.OpCustom,
+	})
+	require.NoError(err)
+	require.NotEqual(protocol.ErrCustomOpCodeUndefined, resp.Opcode, resp.GetError())
+}
+
 func (s *IntegrationTestSuite) TestConcurrency() {
 	require := require.New(s.T())
 


### PR DESCRIPTION
This change adds a new operation to the keyless server that allows a custom function to be defined and applied to process that operation.

The interface allows the custom function to accept the keyless operation payload bytes and return bytes for the response payload.