### PR TITLE
Add standalone pool for RSA requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.9.x
-    - go: 1.10.x
     - go: 1.11.x
     - go: 1.12.x
   allow_failures:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -178,9 +178,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c58e432f2d21c9d694e9e22eccef7c1db9b31caa6cb6db63dd2dc08bf3e9f037"
+  digest = "1:f8f022dbb1e6284be400d2ec4a82fdf9636edc7147fb7e7352b36e8357dd64e5"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus"]
+  packages = [
+    "prometheus",
+    "prometheus/promauto",
+  ]
   pruneopts = "UT"
   revision = "77e8f2ddcfed59ece3a8151879efb2304b5cbbcf"
 
@@ -397,6 +400,7 @@
     "github.com/lziest/ttlcache",
     "github.com/miekg/dns",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,10 +63,6 @@ required = [
 
 [[constraint]]
   branch = "master"
-  name = "go4.org"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/ThalesIgnite/crypto11"
 
 [prune]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Note that for now only one PKCS #11 module can be used at a time, so if you have
 Instructions for installing Go Keyless from `.deb` and `.rpm` packages can be found at [https://pkg.cloudflare.com](https://pkg.cloudflare.com/).
 
 ### Source Installation
-Compiling Go Keyless requires Go 1.7. Binary distributions can be found at [golang.org/dl](https://golang.org/dl/).
+Compiling Go Keyless requires Go 1.11. Binary distributions can be found at [golang.org/dl](https://golang.org/dl/).
 
 Installing the appropriate package for your operating system should leave you with a [working Go installation](http://golang.org/doc/install) and a properly set `GOPATH`.
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -13,16 +13,20 @@ import (
 	"github.com/cloudflare/gokeyless/server/internal/worker"
 )
 
+// A PoolSelector returns the appropraite *worker.Pool based on the request.
+type PoolSelector interface {
+	SelectPool(*protocol.Packet) *worker.Pool
+}
+
 // conn implements the client.Conn interface. One is created to handle each
 // connection from clients over the network. See the documentation in the client
 // package for details.
 type conn struct {
 	conn net.Conn
 	// name used to identify this client in logs
-	name                 string
-	timeout              time.Duration
-	ecdsaPool, otherPool *worker.Pool
-	s                    *Server
+	name     string
+	timeout  time.Duration
+	selector PoolSelector
 
 	closed        uint32 // set to 1 when the conn is closed
 	serverClosing uint32 // set to 1 when the conn is being closed by the server (i.e. not an error)
@@ -62,15 +66,13 @@ func (s *connStats) String() string {
 	return str
 }
 
-func newConn(s *Server, name string, c net.Conn, timeout time.Duration, ecdsa, other *worker.Pool) *conn {
+func newConn(name string, c net.Conn, timeout time.Duration, selector PoolSelector) *conn {
 	return &conn{
-		conn:      c,
-		name:      name,
-		timeout:   timeout,
-		ecdsaPool: ecdsa,
-		otherPool: other,
-		s:         s,
-		closed:    0,
+		conn:     c,
+		name:     name,
+		timeout:  timeout,
+		selector: selector,
+		closed:   0,
 		stats: &connStats{
 			spawnTime: time.Now(),
 		},
@@ -103,7 +105,7 @@ func (c *conn) GetJob() (job interface{}, pool *worker.Pool, ok bool) {
 		return nil, nil, false
 	}
 
-	c.s.stats.logRequest(pkt.Opcode)
+	logRequest(pkt.Opcode)
 	req := request{
 		pkt:      pkt,
 		reqBegin: time.Now(),
@@ -117,16 +119,7 @@ func (c *conn) GetJob() (job interface{}, pool *worker.Pool, ok bool) {
 	c.stats.lastRead.opcode = pkt.Opcode
 	c.stats.lock.Unlock()
 
-	switch pkt.Operation.Opcode {
-	case protocol.OpECDSASignMD5SHA1, protocol.OpECDSASignSHA1,
-		protocol.OpECDSASignSHA224, protocol.OpECDSASignSHA256,
-		protocol.OpECDSASignSHA384, protocol.OpECDSASignSHA512:
-		c.s.stats.logEnqueueECDSARequest()
-		return req, c.ecdsaPool, true
-	default:
-		c.s.stats.logEnqueueOtherRequest()
-		return req, c.otherPool, true
-	}
+	return req, c.selector.SelectPool(pkt), true
 }
 
 func (c *conn) SubmitResult(result interface{}) bool {
@@ -156,7 +149,7 @@ func (c *conn) SubmitResult(result interface{}) bool {
 		return false
 	}
 
-	c.s.stats.logRequestTotalDuration(resp.reqOpcode, resp.reqBegin, resp.err)
+	logRequestTotalDuration(resp.reqOpcode, resp.reqBegin, resp.err)
 
 	c.stats.lock.Lock()
 	c.stats.writes++
@@ -199,7 +192,7 @@ func (c *conn) LogConnErr(err error) {
 	} else if err == io.EOF {
 		log.Debugf("connection %v: closed by client %s", c.name, c.stats)
 	} else {
-		c.s.stats.logConnFailure()
+		logConnFailure()
 		log.Errorf("connection %v: encountered error: %v %s", c.name, err, c.stats)
 	}
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -5,110 +5,75 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/gokeyless/protocol"
 	"github.com/prometheus/client_golang/prometheus"
-)
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
-type statistics struct {
-	requestExecDuration  *prometheus.HistogramVec
-	requestTotalDuration *prometheus.HistogramVec
-	requests             *prometheus.CounterVec
-	keyLoadDuration      prometheus.Histogram
-	connFailures         prometheus.Counter
-	queuedECDSARequests  prometheus.Gauge
-	queuedOtherRequests  prometheus.Gauge
-}
+	"github.com/cloudflare/gokeyless/protocol"
+)
 
 var (
 	// buckets starting at 100 microseconds and doubling until reaching a
 	// maximum of ~3.3 seconds
 	durationBuckets = prometheus.ExponentialBuckets(1e-4, 2.0, 15)
+
+	requestExecDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "keyless_request_exec_duration_per_opcode",
+		Help:    "Time to execute a request not including time in queues, broken down by type and error code.",
+		Buckets: durationBuckets,
+	}, []string{"type", "error"})
+	requestTotalDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "keyless_request_total_duration_per_opcode",
+		Help:    "Total time to satisfy a request including time in queues, broken down by type and error code.",
+		Buckets: durationBuckets,
+	}, []string{"type", "error"})
+	requests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "keyless_requests",
+		Help: "Total number of requests by opcode.",
+	}, []string{"opcode"})
+	keyLoadDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "keyless_key_load_duration",
+		Help:    "Time to load a requested key.",
+		Buckets: durationBuckets,
+	})
+	connFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "keyless_failed_connection",
+		Help: "Number of connection/transport failure, in tls handshake and etc.",
+	})
+	serverUtilization = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "server_utilization",
+		Help: "The [0,1]-percentage utilization of the server's worker threads.",
+	}, []string{"type"})
 )
 
-func newStatistics() *statistics {
-	return &statistics{
-		requestExecDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "keyless_request_exec_duration_per_opcode",
-			Help:    "Time to execute a request not including time in queues, broken down by type and error code.",
-			Buckets: durationBuckets,
-		}, []string{"type", "error"}),
-		requestTotalDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "keyless_request_total_duration_per_opcode",
-			Help:    "Total time to satisfy a request including time in queues, broken down by type and error code.",
-			Buckets: durationBuckets,
-		}, []string{"type", "error"}),
-		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "keyless_requests",
-			Help: "Total number of requests by opcode.",
-		}, []string{"opcode"}),
-		keyLoadDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "keyless_key_load_duration",
-			Help:    "Time to load a requested key.",
-			Buckets: durationBuckets,
-		}),
-		connFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "keyless_failed_connection",
-			Help: "Number of connection/transport failure, in tls handshake and etc.",
-		}),
-		queuedECDSARequests: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "keyless_queued_ecdsa_requests",
-			Help: "Number of queued ECDSA signing requests waiting to be executed.",
-		}),
-		queuedOtherRequests: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "keyless_queued_other_requests",
-			Help: "Number of queued non-ECDSA requests waiting to be executed.",
-		}),
-	}
+func logRequest(opcode protocol.Op) {
+	requests.WithLabelValues(opcode.String()).Inc()
 }
 
-func (stats *statistics) logRequest(opcode protocol.Op) {
-	stats.requests.WithLabelValues(opcode.String()).Inc()
+func logConnFailure() {
+	connFailures.Inc()
 }
 
-func (stats *statistics) logConnFailure() {
-	stats.connFailures.Inc()
-}
-
-func (stats *statistics) logKeyLoadDuration(loadBegin time.Time) {
-	stats.keyLoadDuration.Observe(time.Since(loadBegin).Seconds())
+func logKeyLoadDuration(loadBegin time.Time) {
+	keyLoadDuration.Observe(time.Since(loadBegin).Seconds())
 }
 
 // logRequestExecDuration logs the time taken to execute an operation (not
 // including queueing).
-func (stats *statistics) logRequestExecDuration(opcode protocol.Op, requestBegin time.Time, err protocol.Error) {
-	stats.requestExecDuration.WithLabelValues(opcode.Type(), err.String()).Observe(time.Since(requestBegin).Seconds())
+func logRequestExecDuration(opcode protocol.Op, requestBegin time.Time, err protocol.Error) {
+	requestExecDuration.WithLabelValues(opcode.Type(), err.String()).Observe(time.Since(requestBegin).Seconds())
 }
 
-func (stats *statistics) logRequestTotalDuration(opcode protocol.Op, requestBegin time.Time, err protocol.Error) {
-	stats.requestTotalDuration.WithLabelValues(opcode.Type(), err.String()).Observe(time.Since(requestBegin).Seconds())
+func logRequestTotalDuration(opcode protocol.Op, requestBegin time.Time, err protocol.Error) {
+	requestTotalDuration.WithLabelValues(opcode.Type(), err.String()).Observe(time.Since(requestBegin).Seconds())
 }
-
-func (stats *statistics) logEnqueueECDSARequest() { stats.queuedECDSARequests.Inc() }
-func (stats *statistics) logDeqeueECDSARequest()  { stats.queuedECDSARequests.Dec() }
-func (stats *statistics) logEnqueueOtherRequest() { stats.queuedOtherRequests.Inc() }
-func (stats *statistics) logDeqeueOtherRequest()  { stats.queuedOtherRequests.Dec() }
 
 // MetricsListenAndServe serves Prometheus metrics at metricsAddr
 func (s *Server) MetricsListenAndServe(metricsAddr string) error {
 	if metricsAddr != "" {
-		s.RegisterMetrics()
 		http.Handle("/metrics", prometheus.Handler())
 
 		log.Infof("Serving metrics endpoint at %s/metrics\n", metricsAddr)
 		return http.ListenAndServe(metricsAddr, nil)
 	}
 	return nil
-}
-
-// RegisterMetrics registers server metrics with global prometheus handler
-func (s *Server) RegisterMetrics() {
-	prometheus.MustRegister(
-		s.stats.requestExecDuration,
-		s.stats.requestTotalDuration,
-		s.stats.requests,
-		s.stats.keyLoadDuration,
-		s.stats.connFailures,
-		s.stats.queuedECDSARequests,
-		s.stats.queuedOtherRequests,
-	)
 }

--- a/server/worker_pool.go
+++ b/server/worker_pool.go
@@ -6,31 +6,62 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudflare/gokeyless/protocol"
 	buf_ecdsa "github.com/cloudflare/gokeyless/server/internal/ecdsa"
 	"github.com/cloudflare/gokeyless/server/internal/worker"
 )
 
+// WorkerPoolType represents the different available worker pool types.
+type WorkerPoolType string
+
+// Enumerate the available pool types.
+const (
+	PoolRSA   WorkerPoolType = "rsa"
+	PoolECDSA                = "ecdsa"
+	PoolOther                = "other"
+)
+
+// A WorkerPoolSelector returns the appropriate WorkerPoolType based on the
+// request.
+type WorkerPoolSelector func(pkt *protocol.Packet) WorkerPoolType
+
 type workerPool struct {
+	RSA     *worker.Pool
 	ECDSA   *worker.Pool
 	Other   *worker.Pool
 	Limited *worker.Pool
 
-	bg     *worker.BackgroundPool
-	utilCh chan struct{}
-	utilWg sync.WaitGroup
+	selector WorkerPoolSelector
+	bg       *worker.BackgroundPool
+	utilCh   chan struct{}
+	utilWg   sync.WaitGroup
 }
 
-func newWorkerPool(s *Server) *workerPool {
-	var others []worker.Worker
+const randBufferLen = 1024
+
+func newWorkerPool(s *Server) (*workerPool, error) {
+	// This is mostly so we don't divide by zero below, but will also prevent
+	// inoperable configurations.
+	if s.config.rsaWorkers <= 0 ||
+		s.config.ecdsaWorkers <= 0 ||
+		s.config.otherWorkers <= 0 {
+		return nil, fmt.Errorf("non-zero number of RSA, ECDSA, and Other workers is required")
+	}
+
 	var ecdsas []worker.Worker
+	var rsas []worker.Worker
+	var others []worker.Worker
 	var limiteds []worker.Worker
 	var background []worker.BackgroundWorker
 	rbuf := buf_ecdsa.NewSyncRandBuffer(randBufferLen, elliptic.P256())
-	for i := 0; i < s.config.otherWorkers; i++ {
-		others = append(others, newOtherWorker(s, fmt.Sprintf("other-%v", i)))
+	for i := 0; i < s.config.rsaWorkers; i++ {
+		rsas = append(rsas, newKeylessWorker(s, rbuf, fmt.Sprintf("rsa-%v", i)))
 	}
 	for i := 0; i < s.config.ecdsaWorkers; i++ {
-		ecdsas = append(ecdsas, newECDSAWorker(s, rbuf, fmt.Sprintf("ecdsa-%v", i)))
+		ecdsas = append(ecdsas, newKeylessWorker(s, rbuf, fmt.Sprintf("ecdsa-%v", i)))
+	}
+	for i := 0; i < s.config.otherWorkers; i++ {
+		others = append(others, newKeylessWorker(s, rbuf, fmt.Sprintf("other-%v", i)))
 	}
 	for i := 0; i < s.config.limitedWorkers; i++ {
 		limiteds = append(limiteds, newLimitedWorker(s, fmt.Sprintf("limited-%v", i)))
@@ -40,35 +71,40 @@ func newWorkerPool(s *Server) *workerPool {
 	}
 
 	wp := &workerPool{
-		ECDSA:   worker.NewPool(ecdsas...),
-		Other:   worker.NewPool(others...),
-		Limited: worker.NewPool(limiteds...),
-		bg:      worker.NewBackgroundPool(background...),
-		utilCh:  make(chan struct{}),
+		RSA:      worker.NewPool(rsas...),
+		ECDSA:    worker.NewPool(ecdsas...),
+		Other:    worker.NewPool(others...),
+		Limited:  worker.NewPool(limiteds...),
+		selector: s.config.poolSelector,
+		bg:       worker.NewBackgroundPool(background...),
+		utilCh:   make(chan struct{}),
 	}
 
-	if util := s.config.utilization; util != nil {
-		wp.utilWg.Add(1)
-		go func() {
-			ticker := time.NewTicker(1 * time.Second)
-			for {
-				select {
-				case <-ticker.C:
-					util(
-						float64(wp.Other.Busy())/float64(s.config.otherWorkers),
-						float64(wp.ECDSA.Busy())/float64(s.config.ecdsaWorkers),
-					)
-
-				case <-wp.utilCh:
-					ticker.Stop()
-					wp.utilWg.Done()
-					return
+	for _, label := range []string{"rsa", "ecdsa", "other", "limited"} {
+		serverUtilization.WithLabelValues(label)
+	}
+	wp.utilWg.Add(1)
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				serverUtilization.WithLabelValues("rsa").Set(float64(wp.RSA.Busy()) / float64(s.config.rsaWorkers))
+				serverUtilization.WithLabelValues("ecdsa").Set(float64(wp.ECDSA.Busy()) / float64(s.config.ecdsaWorkers))
+				serverUtilization.WithLabelValues("other").Set(float64(wp.Other.Busy()) / float64(s.config.otherWorkers))
+				if s.config.limitedWorkers > 0 {
+					serverUtilization.WithLabelValues("limited").Set(float64(wp.Limited.Busy()) / float64(s.config.limitedWorkers))
 				}
-			}
-		}()
-	}
 
-	return wp
+			case <-wp.utilCh:
+				ticker.Stop()
+				wp.utilWg.Done()
+				return
+			}
+		}
+	}()
+
+	return wp, nil
 }
 
 func (wp *workerPool) Destroy() {

--- a/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
@@ -1,0 +1,223 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promauto provides constructors for the usual Prometheus metrics that
+// return them already registered with the global registry
+// (prometheus.DefaultRegisterer). This allows very compact code, avoiding any
+// references to the registry altogether, but all the constructors in this
+// package will panic if the registration fails.
+//
+// The following example is a complete program to create a histogram of normally
+// distributed random numbers from the math/rand package:
+//
+//      package main
+//
+//      import (
+//              "math/rand"
+//              "net/http"
+//
+//              "github.com/prometheus/client_golang/prometheus"
+//              "github.com/prometheus/client_golang/prometheus/promauto"
+//              "github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
+//              Name:    "random_numbers",
+//              Help:    "A histogram of normally distributed random numbers.",
+//              Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//      })
+//
+//      func Random() {
+//              for {
+//                      histogram.Observe(rand.NormFloat64())
+//              }
+//      }
+//
+//      func main() {
+//              go Random()
+//              http.Handle("/metrics", promhttp.Handler())
+//              http.ListenAndServe(":1971", nil)
+//      }
+//
+// Prometheus's version of a minimal hello-world program:
+//
+//      package main
+//
+//      import (
+//      	"fmt"
+//      	"net/http"
+//
+//      	"github.com/prometheus/client_golang/prometheus"
+//      	"github.com/prometheus/client_golang/prometheus/promauto"
+//      	"github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      func main() {
+//      	http.Handle("/", promhttp.InstrumentHandlerCounter(
+//      		promauto.NewCounterVec(
+//      			prometheus.CounterOpts{
+//      				Name: "hello_requests_total",
+//      				Help: "Total number of hello-world requests by HTTP code.",
+//      			},
+//      			[]string{"code"},
+//      		),
+//      		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//      			fmt.Fprint(w, "Hello, world!")
+//      		}),
+//      	))
+//      	http.Handle("/metrics", promhttp.Handler())
+//      	http.ListenAndServe(":1971", nil)
+//      }
+//
+// This appears very handy. So why are these constructors locked away in a
+// separate package? There are two caveats:
+//
+// First, in more complex programs, global state is often quite problematic.
+// That's the reason why the metrics constructors in the prometheus package do
+// not interact with the global prometheus.DefaultRegisterer on their own. You
+// are free to use the Register or MustRegister functions to register them with
+// the global prometheus.DefaultRegisterer, but you could as well choose a local
+// Registerer (usually created with prometheus.NewRegistry, but there are other
+// scenarios, e.g. testing).
+//
+// The second issue is that registration may fail, e.g. if a metric inconsistent
+// with the newly to be registered one is already registered. But how to signal
+// and handle a panic in the automatic registration with the default registry?
+// The only way is panicking. While panicking on invalid input provided by the
+// programmer is certainly fine, things are a bit more subtle in this case: You
+// might just add another package to the program, and that package (in its init
+// function) happens to register a metric with the same name as your code. Now,
+// all of a sudden, either your code or the code of the newly imported package
+// panics, depending on initialization order, without any opportunity to handle
+// the case gracefully. Even worse is a scenario where registration happens
+// later during the runtime (e.g. upon loading some kind of plugin), where the
+// panic could be triggered long after the code has been deployed to
+// production. A possibility to panic should be explicitly called out by the
+// Must… idiom, cf. prometheus.MustRegister. But adding a separate set of
+// constructors in the prometheus package called MustRegisterNewCounterVec or
+// similar would be quite unwieldy. Adding an extra MustRegister method to each
+// metric, returning the registered metric, would result in nice code for those
+// using the method, but would pollute every single metric interface for
+// everybody avoiding the global registry.
+//
+// To address both issues, the problematic auto-registering and possibly
+// panicking constructors are all in this package with a clear warning
+// ahead. And whoever cares about avoiding global state and possibly panicking
+// function calls can simply ignore the existence of the promauto package
+// altogether.
+//
+// A final note: There is a similar case in the net/http package of the standard
+// library. It has DefaultServeMux as a global instance of ServeMux, and the
+// Handle function acts on it, panicking if a handler for the same pattern has
+// already been registered. However, one might argue that the whole HTTP routing
+// is usually set up closely together in the same package or file, while
+// Prometheus metrics tend to be spread widely over the codebase, increasing the
+// chance of surprising registration failures. Furthermore, the use of global
+// state in net/http has been criticized widely, and some avoid it altogether.
+package promauto
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounter panics.
+func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	c := prometheus.NewCounter(opts)
+	prometheus.MustRegister(c)
+	return c
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterVec
+// panics.
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	c := prometheus.NewCounterVec(opts, labelNames)
+	prometheus.MustRegister(c)
+	return c
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterFunc
+// panics.
+func NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	g := prometheus.NewCounterFunc(opts, function)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGauge panics.
+func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	g := prometheus.NewGauge(opts)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeVec panics.
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeFunc panics.
+func NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	g := prometheus.NewGaugeFunc(opts, function)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummary panics.
+func NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	s := prometheus.NewSummary(opts)
+	prometheus.MustRegister(s)
+	return s
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummaryVec
+// panics.
+func NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	s := prometheus.NewSummaryVec(opts, labelNames)
+	prometheus.MustRegister(s)
+	return s
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogram panics.
+func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	h := prometheus.NewHistogram(opts)
+	prometheus.MustRegister(h)
+	return h
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogramVec
+// panics.
+func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	h := prometheus.NewHistogramVec(opts, labelNames)
+	prometheus.MustRegister(h)
+	return h
+}


### PR DESCRIPTION
Add standalone pool for RSA requests

This adds a new worker pool, and exposes a hook to customize the logic.

It also simplifies the code by:
- making global metrics package level variables (they were always
  registered with the default Prometheus registry)
- directly exporting the utilization metric (and removing the unused
  "queued requests" metric)
- consolidating logic so any worker can handle any request