### PR TITLE
Build test-nohsm target without hsm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test:
 
 .PHONY: test-nohsm
 test-nohsm:
-	GODEBUG=cgocheck=2 go test -tags pkcs11 -v -cover -race `go list ./... | grep -v /vendor/`
+	GODEBUG=cgocheck=2 go test -v -cover -race `go list ./... | grep -v /vendor/`
 
 .PHONY: test-trust
 test-trust: gokeyless

--- a/server/microbench_test.go
+++ b/server/microbench_test.go
@@ -1,3 +1,5 @@
+// +build pkcs11
+
 package server
 
 import (


### PR DESCRIPTION
On systems without PKCS11 support of any kind installed, the test-nohsm target would fail due to passing in the build tag for pkcs11 support.