### PR TITLE
add certificate expiration metrics for client certificates used in handshake

### DIFF
--- a/certmetrics/metrics.go
+++ b/certmetrics/metrics.go
@@ -1,0 +1,51 @@
+// Package certmetrics will be used to register and emit metrics for certificates in memory
+package certmetrics
+
+import (
+	"crypto/x509"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var certificateExpirationTimes = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "certificate_expiration_timestamp_seconds",
+		Help: "Expiration times of gokeyless certs",
+	},
+	[]string{"serial_no", "cn", "hostnames", "ca", "server", "client"},
+)
+
+// Observe takes in a list of certs and emits its expiration times
+func Observe(certs ...*x509.Certificate) {
+	for _, cert := range certs {
+		hostnames := cert.DNSNames
+		sort.Strings(hostnames)
+		labels := prometheus.Labels{
+			"serial_no": cert.SerialNumber.String(),
+			"cn":        cert.Subject.CommonName,
+			"hostnames": strings.Join(hostnames, ","),
+			"ca":        boolToBinaryString(cert.IsCA),
+			"server":    containsKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth),
+			"client":    containsKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth)}
+		certificateExpirationTimes.With(labels).Set(float64(cert.NotAfter.Unix()))
+	}
+}
+
+func boolToBinaryString(val bool) string {
+	if val {
+		return "1"
+	}
+	return "0"
+}
+
+func containsKeyUsage(a []x509.ExtKeyUsage, x x509.ExtKeyUsage) string {
+	for _, e := range a {
+		if e == x || e == x509.ExtKeyUsageAny {
+			return "1"
+		}
+	}
+	return "0"
+}

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudflare/gokeyless/certmetrics"
+
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/helpers/derhelpers"
 	"github.com/cloudflare/cfssl/log"
@@ -644,7 +646,9 @@ func (s *Server) spawn(l net.Listener, c net.Conn) {
 		tconn.Close()
 		return
 	}
-	limited, err := s.config.isLimited(tconn.ConnectionState())
+	connState := tconn.ConnectionState()
+	certmetrics.Observe(connState.PeerCertificates...)
+	limited, err := s.config.isLimited(connState)
 	if err != nil {
 		log.Errorf("connection %v: could not determine if limited: %v", c.RemoteAddr(), err)
 		tconn.Close()


### PR DESCRIPTION
We want to expose certification expiration metrics of any certificate in memory in gokeyless. This PR will create a package for defining this metric and use it to record expiration times of client certificates sent from any service that connects to gokeyless.
The package can be imported and reused for certificates in any repo. These metrics will be sent to promoetheus where alerts can be configured based on them.