### PR TITLE
add goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 /gokeyless
 *.swp
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,37 @@
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=1
+  - GOFLAGS=-mod=vendor
+  - GOPROXY=off
+builds:
+  - id: gokeyless-darwin
+    binary: gokeyless
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    main: ./cmd/gokeyless
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+  - id: gokeyless-linux
+    binary: gokeyless
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/gokeyless
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+archives:
+  - format: binary
+release:
+  github:
+    owner: cloudflare
+    name: gokeyless
+  prerelease: auto
+changelog:
+  sort: asc

--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,14 @@ test-trust: gokeyless
 .PHONY: benchmark-softhsm
 benchmark-softhsm:
 	go test -tags pkcs11 -v -race ./server -bench HSM -args -softhsm2
+
+# GORELEASER_GITHUB_TOKEN=X make release-github
+# token from https://github.com/settings/tokens/new
+.PHONY: release-github
+release-github:
+	docker run --rm --privileged -v $(PWD):/go/tmp \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-w /go/tmp \
+		--env GORELEASER_GITHUB_TOKEN \
+		neilotoole/xcgo:latest goreleaser --rm-dist
+


### PR DESCRIPTION
although we publish debs on pkg.cloudflare.com, this is mostly handy for
generating the release notes automatically + creating the GH release, and
has the added benefit of adding curl-friendly binary downloads for macOS
and linux