### PR TITLE
Separate forwarding and expand concurrency

### DIFF
--- a/server/internal/client/client.go
+++ b/server/internal/client/client.go
@@ -110,7 +110,7 @@ import (
 // by the user, and once by this monitor goroutine.
 
 const (
-	maxOutstandingRequests = 1024
+	maxOutstandingRequests = 16384
 )
 
 // A note on using Destroy:

--- a/server/internal/client/client.go
+++ b/server/internal/client/client.go
@@ -109,10 +109,6 @@ import (
 // must be safe for the underlying destroy procedure to be invoked twice - once
 // by the user, and once by this monitor goroutine.
 
-const (
-	maxOutstandingRequests = 16384
-)
-
 // A note on using Destroy:
 //
 // We need some mechanism for the code to decide that it wants to kill an
@@ -184,12 +180,12 @@ type ConnHandle struct {
 // SpawnConn spawns a pair of goroutines to handle requests from the client. One
 // goroutine reads jobs from the client and submits them a worker pool, while
 // the other waits of the results of these jobs and writes them to the client.
-func SpawnConn(conn Conn) *ConnHandle {
+func SpawnConn(conn Conn, maxOutstanding int) *ConnHandle {
 	c := &ConnHandle{
 		conn:      conn,
-		responses: make(chan interface{}, maxOutstandingRequests),
+		responses: make(chan interface{}, maxOutstanding),
 		done:      make(chan struct{}),
-		blocker:   newBlocker(maxOutstandingRequests),
+		blocker:   newBlocker(maxOutstanding),
 	}
 	c.wg.Add(2)
 

--- a/server/internal/client/client_test.go
+++ b/server/internal/client/client_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cloudflare/gokeyless/server/internal/worker"
 )
 
+const maxOutstandingRequests = 1024
+
 func TestBlocker(t *testing.T) {
 	b := newBlocker(1)
 	if b.Do() {
@@ -99,7 +101,7 @@ func (d *dummyWorker) Do(job interface{}) (result interface{}) { return job }
 func newConnSetup() (conn *dummyConn, handle *ConnHandle) {
 	pool := worker.NewPool(&dummyWorker{})
 	conn = newDummyConn(pool)
-	return conn, SpawnConn(conn)
+	return conn, SpawnConn(conn, maxOutstandingRequests)
 }
 
 func TestClientBasic(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -691,7 +691,7 @@ func (s *Server) spawn(l net.Listener, c net.Conn) {
 		tconn.Close()
 		return
 	}
-	handle := client.SpawnConn(conn)
+	handle := client.SpawnConn(conn, s.config.maxConnPendingRequests)
 	s.listeners[l][handle] = struct{}{}
 	s.mtx.Unlock()
 	log.Debugf("%s: spawned", connStr)
@@ -798,6 +798,7 @@ type ServeConfig struct {
 	otherWorkers            int
 	remoteWorkers           int
 	limitedWorkers          int
+	maxConnPendingRequests  int
 	tcpTimeout, unixTimeout time.Duration
 	isLimited               func(state tls.ConnectionState) (bool, error)
 	customOpFunc            CustomOpFunction
@@ -823,15 +824,16 @@ func DefaultServeConfig() *ServeConfig {
 		n = 2
 	}
 	return &ServeConfig{
-		rsaWorkers:     n,
-		ecdsaWorkers:   n,
-		otherWorkers:   2,
-		remoteWorkers:  2,
-		limitedWorkers: 0,
-		tcpTimeout:     defaultTCPTimeout,
-		unixTimeout:    defaultUnixTimeout,
-		isLimited:      func(state tls.ConnectionState) (bool, error) { return false, nil },
-		poolSelector:   defaultPoolSelector,
+		rsaWorkers:             n,
+		ecdsaWorkers:           n,
+		otherWorkers:           2,
+		remoteWorkers:          2,
+		limitedWorkers:         0,
+		tcpTimeout:             defaultTCPTimeout,
+		unixTimeout:            defaultUnixTimeout,
+		maxConnPendingRequests: 1024,
+		isLimited:              func(state tls.ConnectionState) (bool, error) { return false, nil },
+		poolSelector:           defaultPoolSelector,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -631,6 +631,8 @@ func (s *poolSelector) SelectPool(pkt *protocol.Packet) *worker.Pool {
 		return s.wp.RSA
 	case PoolECDSA:
 		return s.wp.ECDSA
+	case PoolRemote:
+		return s.wp.Remote
 	default:
 		return s.wp.Other
 	}
@@ -794,6 +796,7 @@ type ServeConfig struct {
 	rsaWorkers              int
 	ecdsaWorkers            int
 	otherWorkers            int
+	remoteWorkers           int
 	limitedWorkers          int
 	tcpTimeout, unixTimeout time.Duration
 	isLimited               func(state tls.ConnectionState) (bool, error)
@@ -823,6 +826,7 @@ func DefaultServeConfig() *ServeConfig {
 		rsaWorkers:     n,
 		ecdsaWorkers:   n,
 		otherWorkers:   2,
+		remoteWorkers:  2,
 		limitedWorkers: 0,
 		tcpTimeout:     defaultTCPTimeout,
 		unixTimeout:    defaultUnixTimeout,
@@ -879,6 +883,17 @@ func (s *ServeConfig) WithECDSAWorkers(n int) *ServeConfig {
 // ECDSAWorkers returns the number of ECDSA worker goroutines.
 func (s *ServeConfig) ECDSAWorkers() int {
 	return s.ecdsaWorkers
+}
+
+// WithRemoteWorkers specifies the number of remote goroutines to use.
+func (s *ServeConfig) WithRemoteWorkers(n int) *ServeConfig {
+	s.remoteWorkers = n
+	return s
+}
+
+// RemoteWorkers returns the number of other worker goroutines.
+func (s *ServeConfig) RemoteWorkers() int {
+	return s.remoteWorkers
 }
 
 // WithOtherWorkers specifies the number of other worker goroutines to use.


### PR DESCRIPTION
Experience has shown that certain applications require distinctions
among their worker pools and a high concurrency per connection.