### PR TITLE
add goreleaser snapshot and release action, enable pkcs11 in built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+      - run: make release-github
+        env:
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,16 @@
+name: Image snapshots
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make snapshot
+      - name: Archive snapshot artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
     goarch:
       - amd64
     main: ./cmd/gokeyless
+    flags:
+      - -tags=pkcs11
     ldflags:
       - -s -w -X main.version={{.Version}}
   - id: gokeyless-linux
@@ -23,6 +25,8 @@ builds:
     goarch:
       - amd64
     main: ./cmd/gokeyless
+    flags:
+      - -tags=pkcs11
     ldflags:
       - -s -w -X main.version={{.Version}}
       - -linkmode external -extldflags "-static"

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,11 @@ release-github:
 		--env GORELEASER_GITHUB_TOKEN \
 		neilotoole/xcgo:latest goreleaser --rm-dist
 
+
+.PHONY: snapshot
+snapshot:
+	docker run --rm --privileged -v $(PWD):/go/tmp \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-w /go/tmp \
+		neilotoole/xcgo:latest goreleaser --snapshot --rm-dist
+

--- a/server/pkcs11.go
+++ b/server/pkcs11.go
@@ -1,9 +1,11 @@
+//go:build pkcs11 && cgo
 // +build pkcs11,cgo
 
 package server
 
 import (
 	"crypto"
+	"fmt"
 
 	"github.com/cloudflare/gokeyless/internal/rfc7512"
 )
@@ -15,10 +17,14 @@ func DefaultLoadURI(uri string) (crypto.Signer, error) {
 	// as waiting for network to be up.
 	pk11uri, err := rfc7512.ParsePKCS11URI(uri)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse pkcs11: %w", err)
 	}
 
-	return rfc7512.LoadPKCS11Signer(pk11uri)
+	signer, err := rfc7512.LoadPKCS11Signer(pk11uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load pkcs11: %w", err)
+	}
+	return signer, nil
 }
 
 func loadPKCS11URI(uri string) (crypto.Signer, error) {


### PR DESCRIPTION
now if you go to https://github.com/cloudflare/gokeyless/actions/runs/4494483693 (test run from every commit) you can download a binary for linux + macOS