### PR TITLE
SECENG-9843 start publishing rpm and deb packages via goreleaser nfpms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: goreleaser
 
 on:
   push:
+    branches:
+      - master
     tags:
       - "*"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,14 @@ release:
   prerelease: auto
 changelog:
   sort: asc
+nfpms:
+  - id: keyless-nfpm
+    package_name: gokeyless
+    file_name_template: "gokeyless_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    homepage: https://github.com/cloudflare/gokeyless
+    maintainer: SSL Cloudflare <security-engineering@cloudflare.com>
+    description: Go implementation of keyless protocol
+    license: Cloudflare
+    formats:
+      - deb
+      - rpm

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ release-github:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/tmp \
 		--env GORELEASER_GITHUB_TOKEN \
-		neilotoole/xcgo:latest goreleaser --rm-dist
+		neilotoole/xcgo:latest goreleaser release --rm-dist
 
 
 .PHONY: snapshot


### PR DESCRIPTION
Creates a release alongwith deb and rpm packages on a tag push to master. We can download the assets from here 
https://github.com/cloudflare/gokeyless/releases/tag/v1.6.6