### PR TITLE
fix: add missing content to deb and rpm packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,3 +50,32 @@ nfpms:
     formats:
       - deb
       - rpm
+    overrides:
+      deb:
+        scripts:
+          preinstall: pkg/debian/before-install.sh
+          postinstall: pkg/debian/after-install.sh
+          preremove: pkg/debian/before-remove.sh
+      rpm:
+        scripts:
+          preinstall: pkg/centos/before-install.sh
+          postinstall: pkg/centos/after-install.sh
+          preremove: pkg/centos/before-remove.sh
+    contents:
+      - src: pkg/gokeyless.service
+        dst: /lib/systemd/system/gokeyless.service
+        file_info:
+          mode: 0644
+      - src: pkg/gokeyless.sysv
+        dst: /etc/init.d/gokeyless
+        file_info:
+          mode: 0755
+      - src: pkg/keyless_cacert.pem
+        dst: /etc/keyless/keyless_cacert.pem
+        file_info:
+          mode: 0644
+      - src: pkg/gokeyless.yaml
+        dst: /etc/keyless/gokeyless.yaml
+        file_info:
+          mode: 0600
+        type: "config|noreplace"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,10 +70,12 @@ nfpms:
         dst: /etc/init.d/gokeyless
         file_info:
           mode: 0755
+        type: config
       - src: pkg/keyless_cacert.pem
         dst: /etc/keyless/keyless_cacert.pem
         file_info:
           mode: 0644
+        type: config
       - src: pkg/gokeyless.yaml
         dst: /etc/keyless/gokeyless.yaml
         file_info:


### PR DESCRIPTION
Since [1.6.7](https://github.com/cloudflare/gokeyless/pull/318) and the switch to nfpms, deb package contains only the binary, we are missing all other content in the package:

```
$ dpkg -L gokeyless
/usr
/usr/local
/usr/local/bin
/usr/local/bin/gokeyless
$ /usr/local/bin/gokeyless -v
gokeyless version 1.6.7
```

vs for 1.6.6:
```
$ dpkg -L gokeyless
/.
/etc
/etc/keyless
/etc/keyless/keyless_cacert.pem
/etc/keyless/keys
/etc/keyless/gokeyless.yaml
/etc/init.d
/etc/init.d/gokeyless
/usr
/usr/local
/usr/local/bin
/usr/local/bin/gokeyless
/usr/share
/usr/share/doc
/usr/share/doc/gokeyless
/usr/share/doc/gokeyless/changelog.gz
/lib
/lib/systemd
/lib/systemd/system
/lib/systemd/system/gokeyless.service
$ gokeyless -v
gokeyless version 1.6.6
```

I've tested locally to build the deb with goreleaser+nfpms successfully. 



