### PR TITLE
force use of native go dns resolver

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - amd64
     main: ./cmd/gokeyless
     flags:
-      - -tags=pkcs11
+      - -tags=pkcs11,netgo
     ldflags:
       - -s -w -X main.version={{.Version}}
   - id: gokeyless-linux
@@ -26,7 +26,7 @@ builds:
       - amd64
     main: ./cmd/gokeyless
     flags:
-      - -tags=pkcs11
+      - -tags=pkcs11,netgo
     ldflags:
       - -s -w -X main.version={{.Version}}
       - -linkmode external -extldflags "-static"


### PR DESCRIPTION
the pkcs11 support necessitates the use of cgo, which in turn opts in Go to use a C library for dns resolution (https://pkg.go.dev/net#hdr-Name_Resolution)

on (at least) Ubuntu 22 x64, this causes the initialization process to fail. `GODEBUG=netdns=go` seems to fix this, so this change updates the build process to use the native resolver.

unclear exactly why this problem only popped up now, https://github.com/golang/go/issues/30310 seems to be a similar report despite being older but the conditions match (we are using `-linkmode external -extldflags "-static"`)

Resolves #321