### PR TITLE
skip running goreleaser when commits are merged into master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: goreleaser
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
 


### PR DESCRIPTION
prevents 
![image](https://github.com/cloudflare/gokeyless/assets/707582/822a6076-de05-4816-8a88-a7d7348c034e)
