### PR TITLE
update services to expect binary in usr/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,7 @@ nfpms:
     formats:
       - deb
       - rpm
+    bindir: /usr/bin # explicitly defining the default
     overrides:
       deb:
         scripts:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION := $(shell git describe --tags --abbrev=0 | tr -d '[:alpha:]')
 LDFLAGS := "-X main.version=$(VERSION)"
 
 DESTDIR                      := build
-PREFIX                       := usr/local
+PREFIX                       := usr
 INSTALL_BIN                  := $(DESTDIR)/$(PREFIX)/bin
 INIT_PREFIX                  := $(DESTDIR)/etc/init.d
 SYSTEMD_PREFIX               := $(DESTDIR)/lib/systemd/system

--- a/pkg/gokeyless.service
+++ b/pkg/gokeyless.service
@@ -7,7 +7,7 @@ Type=simple
 User=keyless
 Group=keyless
 WorkingDirectory=/etc/keyless
-ExecStart=/usr/local/bin/gokeyless
+ExecStart=/usr/bin/gokeyless
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/gokeyless.sysv
+++ b/pkg/gokeyless.sysv
@@ -22,7 +22,7 @@ if [ `id -u` -ne 0 ]; then
 fi
 
 name=gokeyless
-program=/usr/local/bin/gokeyless
+program=/usr/bin/gokeyless
 pidfile="/var/run/$name.pid"
 
 # Optional


### PR DESCRIPTION
This seems to be more correct than user/local/bin, and goreleaser's defaults corroborate that.

Resolves #328, as this behavior is the systemd default Adds on to #320 as well.