### PR TITLE
add command to debug loading from keystore

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,10 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: sudo apt-get update && sudo apt-get install -y softhsm2
+      - run: sudo cp -r tests/testdata/tokens/* /var/lib/softhsm/token
       - run: make snapshot
       # latest snapshot looks like dist/gokeyless_0.0.0-SNAPSHOT-99d510e_linux_amd64.deb
       - run: sudo dpkg -i dist/*.deb
       - run: sudo gokeyless --version
+      - run: gokeyless --keystore-debug -c tests/testdata/keystoredebug-dir.yaml
+      # this line reproduces behavior in #324
+      # - run: sudo gokeyless --keystore-debug -c tests/testdata/keystoredebug-softhsm.yaml
       - name: ensure systemd service can start
         run: sudo systemctl start gokeyless
       - name: ensure keyless user exists

--- a/tests/testdata/keystoredebug-dir.yaml
+++ b/tests/testdata/keystoredebug-dir.yaml
@@ -1,0 +1,2 @@
+private_key_stores:
+  - dir: tests/

--- a/tests/testdata/keystoredebug-softhsm.yaml
+++ b/tests/testdata/keystoredebug-softhsm.yaml
@@ -1,0 +1,2 @@
+private_key_stores:
+  - uri: pkcs11:token=SoftHSM2%20Token;id=%03?module-path=/usr/lib/softhsm/libsofthsm2.so&pin-value=1234


### PR DESCRIPTION
```
❯ ./gokeyless --keystore-debug -c ~/Desktop/nicky.yaml
2023/05/17 11:04:38 [INFO] loading pkcs11:token=SoftHSM2%20Token;id=%03?module-path=/opt/homebrew/opt/softhsm/lib/softhsm/libsofthsm2.so&pin-value=1234...
2023/05/17 11:04:38 [DEBUG] add signer with SKI: 406550d87609ecae021a83ef2c1f372c08f42699 (https://crt.sh/?ski=406550d87609ecae021a83ef2c1f372c08f42699)
```

Through this, reproduction of #324 is possible in tests, without the need to setup PKI.