### PR TITLE
fix github token env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/setup-go@v3
       - run: make release-github
         env:
-          GORELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ release-github:
 	docker run --rm --privileged -v $(PWD):/go/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/tmp \
-		--env GORELEASER_GITHUB_TOKEN \
+		--env GITHUB_TOKEN \
 		ghcr.io/gythialy/golang-cross:latest --clean
 
 


### PR DESCRIPTION
it changed during 77129999fa6e12304b5bbbe0a19b2008abb45cd7, release process hasn't been tested until now