### PR TITLE
build with vcs info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
     main: ./cmd/gokeyless
     flags:
       - -tags=pkcs11,netgo
-      - -buildvcs=false
     ldflags:
       - -s -w -X main.version={{.Version}}
   - id: gokeyless-linux
@@ -28,7 +27,6 @@ builds:
     main: ./cmd/gokeyless
     flags:
       - -tags=pkcs11,netgo
-      - -buildvcs=false
     ldflags:
       - -s -w -X main.version={{.Version}}
 archives:

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ release-github:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/tmp \
 		--env GITHUB_TOKEN \
-		ghcr.io/gythialy/golang-cross:latest --clean
+		ghcr.io/goreleaser/goreleaser-cross:latest --clean
 
 
 .PHONY: snapshot
@@ -127,5 +127,5 @@ snapshot:
 	docker run --rm --privileged -v $(PWD):/go/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/tmp \
-		ghcr.io/gythialy/golang-cross:latest --clean --snapshot --skip-publish
+		ghcr.io/goreleaser/goreleaser-cross:latest --clean --snapshot --skip-publish
 

--- a/cmd/gokeyless/gokeyless.go
+++ b/cmd/gokeyless/gokeyless.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -230,6 +231,10 @@ func runMain() error {
 		return nil
 	case versionMode:
 		fmt.Println("gokeyless version", version)
+		if info, ok := debug.ReadBuildInfo(); ok {
+			fmt.Printf("%s built with %s\n", info.Path, info.GoVersion)
+		}
+
 		return nil
 	case manualMode && configMode:
 		return fmt.Errorf("can't specify both --manual-activation and --config-only!")


### PR DESCRIPTION
golang-cross didn't properly work with VCS stamping, which goreleaser seems to require.