### PR TITLE
Add docker image build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,47 @@ jobs:
       - run: make release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          # github container registry
+          - registry: "ghcr.io"
+            username: ${{ github.actor }}
+            password_secret: GITHUB_TOKEN
+            image: ghcr.io/cloudflare/gokeyless
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Docker hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.username }}
+          password: ${{ secrets[matrix.password_secret] }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ matrix.image }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.21 as builder
+WORKDIR /gokeyless
+COPY . .
+RUN env GOOS=linux GOARCH=amd64 make gokeyless
+
+FROM golang:1.21
+WORKDIR /gokeyless
+COPY --from=builder /gokeyless/gokeyless gokeyless
+ENTRYPOINT ["./gokeyless"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ You should add your Cloudflare account details to the configuration file, and op
 
 Each option can optionally be overridden via environment variables or command-line arguments. Run `gokeyless -h` to see the full list of available options.
 
+## Running using Docker Image
+
+A docker image is published that contains a built binary file and startup instruction for the `gokeyless` process.  An example of the usage of this docker file is in `docker-compose.example.yaml`
+
+This examples shows how you may provide the same configuration options through environment variables and provide a mount with a directory for private keys instead of through a `gokeyless.yaml` file.
+
 ## Testing
 
 Unit tests and benchmarks have been implemented for various parts of Go Keyless via `go test`. Most of the tests run out of the box, but some setup is necessary to run the HSM-related tests:

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,25 @@
+version: "3"
+services:
+  gokeyless:
+    platform: linux/amd64
+    container_name: gokeyless
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./tests/testdata/:/gokeyless/config
+    environment:
+      # - KEYLESS_HOSTNAME=keyserver.keyless.com
+      # - KEYLESS_ZONE_ID=5c7004f5221ba2a24c998bd609244a39
+      # - KEYLESS_ORIGIN_CA_API_KEY=ORIGIN_CA_API_KEY_HERE
+      - KEYLESS_AUTH_CERT=/gokeyless/config/server.pem
+      - KEYLESS_AUTH_KEY=/gokeyless/config/server-key.pem
+      - KEYLESS_AUTH_CSR=/gokeyless/config/csr.json
+      - KEYLESS_CLOUDFLARE_CA_CERT=/gokeyless/config/ca.pem
+      - KEYLESS_LOGLEVEL=0
+      - KEYLESS_PORT=2407
+      - KEYLESS_METRICS_PORT=2406
+      - KEYLESS_PRIVATE_KEY_DIRS=/gokeyless/config
+    ports:
+      - "2406:2406"
+      - "2407:2407"


### PR DESCRIPTION
I will update this with some documentation about using the containerized gokeyless, and I believe I can add some integration test since gokeyless doesn't need to phone home unless to get new certs, but we already have dev certs configured in the repo.