### PR TITLE
Github action for build and push image uses Go 1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.0'
+      - run: go version
+
       - run: make release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +43,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.0'
+      - run: go version
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
The build-and-push github action job is failing due to an incompatible go version. This resolves that issue https://github.com/cloudflare/gokeyless/actions/runs/14381784355/job/40327122988?pr=510
```
 > [linux/amd64 builder 5/5] RUN env GOOS=linux GOARCH=amd64 make gokeyless:
0.814 go build -tags pkcs11 -ldflags "-X main.version=dev" -o gokeyless ./cmd/gokeyless/...
0.818 go: go.mod requires go >= 1.23 (running go 1.21.13; GOTOOLCHAIN=local)
0.819 make: *** [Makefile:88: gokeyless] Error 1
```