### PR TITLE
Update GoReleaser archive configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}}
 archives:
-  - format: binary
+  - formats: [binary]
 release:
   github:
     owner: cloudflare


### PR DESCRIPTION
# PR Summary
This small PR updates the GoReleaser configuration to resolve the following warning: 
```
DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```