### PR TITLE
Add CI job to create a RHEL8 targeted binary with lower glibc version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -48,3 +52,44 @@ jobs:
         run: go install ./vendor/golang.org/x/lint/golint
       - name: Go Lint
         run: make gokeyless vet lint
+  # Verify that the CGO binary built for RHEL 8 does not exceed GLIBC 2.28.
+  # This catches upstream toolchain changes (e.g. goreleaser-cross base image
+  # bumps) that silently raise the GLIBC floor. See SECENG-13556.
+  build-el8:
+    runs-on: ubuntu-latest
+    container:
+      image: rockylinux:8
+    steps:
+      - name: Install system dependencies
+        run: dnf install -y gcc make libtool-ltdl-devel git findutils
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fix git ownership
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install Go 1.24.1
+        run: |
+          curl -sL https://go.dev/dl/go1.24.1.linux-amd64.tar.gz -o /tmp/go.tar.gz
+          tar -C /usr/local -xzf /tmp/go.tar.gz
+          rm /tmp/go.tar.gz
+          ln -s /usr/local/go/bin/go /usr/local/bin/go
+          ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+          go version
+
+      - name: Build gokeyless binary
+        run: make build/usr/bin/gokeyless
+
+      - name: Verify GLIBC compatibility
+        run: |
+          MAX_GLIBC=$(objdump -T build/usr/bin/gokeyless | grep -oP 'GLIBC_\d+\.\d+' | sort -uV | tail -1)
+          echo "Maximum GLIBC version required: $MAX_GLIBC"
+          MAX_VER=$(echo "$MAX_GLIBC" | grep -oP '\d+\.\d+')
+          if [ "$(printf '%s\n' "2.28" "$MAX_VER" | sort -V | tail -1)" != "2.28" ]; then
+            echo "ERROR: Binary requires $MAX_GLIBC which is newer than GLIBC 2.28 (RHEL 8)"
+            exit 1
+          fi
+          echo "OK: Binary is compatible with RHEL 8 (GLIBC 2.28)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,89 @@ jobs:
       - run: make release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Build a GLIBC 2.28-compatible RPM for RHEL 8 / EL8 customers.
+  # The main goreleaser job builds inside goreleaser-cross (Ubuntu 24.04,
+  # GLIBC 2.39) which produces binaries incompatible with RHEL 8.
+  # This job compiles inside Rocky Linux 8 (GLIBC 2.28) to guarantee
+  # compatibility. See: SECENG-13556, ESCALATION-2261
+  build-el8-rpm:
+    runs-on: ubuntu-latest
+    needs: goreleaser # release must exist before we can upload assets
+    container:
+      image: rockylinux:8
+    steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y gcc make libtool-ltdl-devel git findutils
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fix git ownership
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install Go 1.24.1
+        run: |
+          curl -sL https://go.dev/dl/go1.24.1.linux-amd64.tar.gz -o /tmp/go.tar.gz
+          tar -C /usr/local -xzf /tmp/go.tar.gz
+          rm /tmp/go.tar.gz
+          # Make Go available for subsequent steps
+          ln -s /usr/local/go/bin/go /usr/local/bin/go
+          ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+          go version
+
+      - name: Build gokeyless binary
+        run: make build/usr/bin/gokeyless
+
+      - name: Verify GLIBC compatibility
+        run: |
+          # Ensure the binary does not require GLIBC newer than 2.28
+          objdump -T build/usr/bin/gokeyless | grep -oP 'GLIBC_\d+\.\d+' | sort -uV | tail -1
+          MAX_GLIBC=$(objdump -T build/usr/bin/gokeyless | grep -oP 'GLIBC_\d+\.\d+' | sort -uV | tail -1)
+          echo "Maximum GLIBC version required: $MAX_GLIBC"
+          # Extract version number and compare
+          MAX_VER=$(echo "$MAX_GLIBC" | grep -oP '\d+\.\d+')
+          if [ "$(printf '%s\n' "2.28" "$MAX_VER" | sort -V | tail -1)" != "2.28" ]; then
+            echo "ERROR: Binary requires $MAX_GLIBC which is newer than GLIBC 2.28 (RHEL 8)"
+            exit 1
+          fi
+          echo "OK: Binary is compatible with RHEL 8 (GLIBC 2.28)"
+
+      - name: Install nfpm
+        run: |
+          curl -sL https://github.com/goreleaser/nfpm/releases/download/v2.46.3/nfpm_2.46.3_Linux_x86_64.tar.gz -o /tmp/nfpm.tar.gz
+          tar -C /usr/local/bin -xzf /tmp/nfpm.tar.gz nfpm
+          rm /tmp/nfpm.tar.gz
+
+      - name: Determine version
+        id: version
+        run: |
+          # Strip leading 'v' from the tag to get the version number
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build el8 RPM
+        run: |
+          nfpm package \
+            --config nfpm-el8.yml \
+            --packager rpm \
+            --target "gokeyless-${VERSION}-1.el8.x86_64.rpm"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Upload RPM to GitHub release
+        run: |
+          # Install gh CLI
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          dnf install -y gh
+          # Upload the el8 RPM as a release asset
+          gh release upload "$GITHUB_REF_NAME" gokeyless-*.el8.x86_64.rpm --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:

--- a/nfpm-el8.yml
+++ b/nfpm-el8.yml
@@ -1,0 +1,60 @@
+# nfpm configuration for building RHEL 8 / EL8-compatible RPM packages.
+#
+# This exists because the main goreleaser pipeline builds inside
+# ghcr.io/goreleaser/goreleaser-cross:latest (Ubuntu 24.04, GLIBC 2.39),
+# producing binaries that are incompatible with RHEL 8 (GLIBC 2.28).
+#
+# This config is used by the build-el8-rpm CI job which compiles inside
+# a Rocky Linux 8 container to guarantee GLIBC 2.28 compatibility.
+#
+# See: SECENG-13556, ESCALATION-2261
+
+name: gokeyless
+arch: amd64
+platform: linux
+version: ${VERSION}
+maintainer: SSL Cloudflare <security-engineering@cloudflare.com>
+description: Go implementation of keyless protocol
+vendor: Cloudflare
+homepage: https://github.com/cloudflare/gokeyless
+license: Cloudflare
+
+depends:
+  - libtool-ltdl
+
+contents:
+  - src: build/usr/bin/gokeyless
+    dst: /usr/bin/gokeyless
+    file_info:
+      mode: 0755
+
+  - src: pkg/gokeyless.service
+    dst: /lib/systemd/system/gokeyless.service
+    file_info:
+      mode: 0644
+
+  - src: pkg/gokeyless.sysv
+    dst: /etc/init.d/gokeyless
+    type: config
+    file_info:
+      mode: 0755
+
+  - src: pkg/keyless_cacert.pem
+    dst: /etc/keyless/keyless_cacert.pem
+    type: config
+    file_info:
+      mode: 0644
+
+  - src: pkg/gokeyless.yaml
+    dst: /etc/keyless/gokeyless.yaml
+    type: config|noreplace
+    file_info:
+      mode: 0600
+
+scripts:
+  preinstall: pkg/centos/before-install.sh
+  postinstall: pkg/centos/after-install.sh
+  preremove: pkg/centos/before-remove.sh
+
+rpm:
+  group: System Environment/Daemons


### PR DESCRIPTION
Summary

The gokeyless RPM/DEB packages built since v1.17.4 are incompatible with RHEL 8 and RHEL 9. The upstream goreleaser-cross build image (pinned to :latest) silently rebased from Debian Bullseye (GLIBC 2.31) to Ubuntu Noble (GLIBC 2.39). Since CGO is enabled for PKCS#11/HSM support, the resulting binary is dynamically linked and requires a newer GLIBC than these distros provide.

What this PR adds:
- A build-el8-rpm job in the release workflow that compiles gokeyless inside a Rocky Linux 8 container (GLIBC 2.28) and uploads an EL8-compatible RPM as a release asset
- A build-el8 CI job on every push/PR to verify the binary never exceeds GLIBC 2.28, preventing this class of silent regression
- Explicit permissions: contents: read on the CI workflow